### PR TITLE
Change editor to use U32 internally and treat any external data as UTF-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,7 @@ add_subdirectory(ext/logger ${CMAKE_BINARY_DIR}/logger)
 list(APPEND extlibs logger)
 
 add_subdirectory(ext/fmt ${CMAKE_BINARY_DIR}/fmt EXCLUDE_FROM_ALL)
+set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 list(APPEND extlibs fmt)
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 cmake_minimum_required(VERSION 3.22)
 project(goatedit VERSION 0.1)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # When changing the Assets/CMake/Info.plist.in - which will rebuild the bundle Info.plist we must
 # reset the cache in macos for this to take effect...
@@ -22,6 +22,7 @@ option(GEDIT_BUILD_SDL3 "Build SDL3" OFF)
 option(GEDIT_BUILD_SDL2 "Build SDL2" ON)
 
 set(SDL_HOME /usr/local)
+
 
 list(APPEND appsrc main.cpp)
 
@@ -48,6 +49,10 @@ if (NOT EXISTS ${CMAKE_SOURCE_DIR}/ext/dukglue)
     execute_process(COMMAND git clone https://github.com/Aloshi/dukglue ${CMAKE_SOURCE_DIR}/ext/dukglue)
 endif ()
 
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/ext/fmt)
+    message(WARNING "Installing fmt library")
+    execute_process(COMMAND git clone https://github.com/fmtlib/fmt ${CMAKE_SOURCE_DIR}/ext/fmt)
+endif()
 #
 # Note: This won't fly as we need to pre-process this further...
 #
@@ -250,12 +255,17 @@ target_compile_definitions(${CUR_TARGET} PUBLIC GEDIT_VERSION_PATCH=0)
 set(DUKTAPE_HOME ext/duktape-2.7.0/src)
 set(DUKTAPE_EXTRAS ext/duktape-2.7.0/extras)
 set(DUKGLUE_HOME ext/dukglue)
+set(FMT_HOME ext/fmt)
+
 
 list(APPEND duktape ${DUKTAPE_HOME}/duktape.c ${DUKTAPE_HOME}/duk_config.h ${DUKTAPE_HOME}/duktape.h)
 list(APPEND duktape ${DUKTAPE_EXTRAS}/module-node/duk_module_node.c)
 
 add_subdirectory(ext/logger ${CMAKE_BINARY_DIR}/logger)
 list(APPEND extlibs logger)
+
+add_subdirectory(ext/fmt ${CMAKE_BINARY_DIR}/fmt)
+list(APPEND extlibs fmt)
 
 #
 # Editor
@@ -432,6 +442,7 @@ list(APPEND includedirs ${SDL_HOME}/include)
 list(APPEND includedirs ${DUKGLUE_HOME}/include)
 list(APPEND includedirs ${DUKTAPE_HOME})
 list(APPEND includedirs ${DUKTAPE_EXTRAS}/module-node)
+list(APPEND includedirs ${FMT_HOME}/include)
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ list(APPEND duktape ${DUKTAPE_EXTRAS}/module-node/duk_module_node.c)
 add_subdirectory(ext/logger ${CMAKE_BINARY_DIR}/logger)
 list(APPEND extlibs logger)
 
-add_subdirectory(ext/fmt ${CMAKE_BINARY_DIR}/fmt)
+add_subdirectory(ext/fmt ${CMAKE_BINARY_DIR}/fmt EXCLUDE_FROM_ALL)
 list(APPEND extlibs fmt)
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ list(APPEND editorsrc src/Core/Plugins/PluginExecutor.cpp src/Core/Plugins/Plugi
 list(APPEND editorsrc src/Core/KeypressAndActionHandler.h)
 
 # utility stuff
+list(APPEND editorsrc src/Core/ConvertUTF.c src/Core/ConvertUTF.h)
 list(APPEND editorsrc src/Core/ColorRGBA.cpp src/Core/ColorRGBA.h)
 list(APPEND editorsrc src/Core/HexDump.cpp src/Core/HexDump.h)
 list(APPEND editorsrc src/Core/Glob.cpp src/Core/Glob.h)
@@ -293,6 +294,7 @@ list(APPEND editorsrc src/Core/NamedColors.cpp src/Core/NamedColors.h)
 list(APPEND editorsrc src/Core/PathUtil.cpp src/Core/PathUtil.h)
 list(APPEND editorsrc src/Core/StrUtil.cpp src/Core/StrUtil.h)
 list(APPEND editorsrc src/Core/TypeUtil.h)
+list(APPEND editorsrc src/Core/UnicodeHelper.cpp src/Core/UnicodeHelper.h)
 
 # Keyboard handling
 list(APPEND editorsrc src/Core/KeyPress.cpp src/Core/KeyPress.h)
@@ -452,6 +454,7 @@ list(APPEND utestsrc utests/test_editorapi.cpp)
 list(APPEND utestsrc utests/test_jsengine.cpp)
 list(APPEND utestsrc utests/test_keymapping.cpp)
 list(APPEND utestsrc utests/test_logger.cpp)
+list(APPEND utestsrc utests/test_strutil.cpp)
 list(APPEND utestsrc utests/test_textbuffer.cpp)
 list(APPEND utestsrc utests/test_theme.cpp)
 list(APPEND utestsrc utests/test_workspace.cpp)

--- a/main.cpp
+++ b/main.cpp
@@ -3,11 +3,11 @@
 //
 /*
  * TO-DO List
- * - Change loader to convert everything to UTF32 - for fast rendering
- * - Need a new text renderer -> handling of unicode
+ * - Language parser should operate on U32
  * + Exclude/Ignore directories for Monitor is a must
  *   Introduce a 'FolderMonitor' section in the config, should have 'Enable', 'Exclude'-list (glob-patterns)
- * - Monitoring a path that changes quickly (like the build directory) will cause seg-faults
+ * - Introduce some delay in the monitoring allowing for add/remove before we refresh the editor
+     Monitoring a path that changes quickly (like the build directory) will cause seg-faults
  * - Undo does not properly reparse the area of the re-pasted data
  * + There are segfaults in copy/paste
  * - Adding an additional ')' when the previous char is '(' should be ignored, typing: '(',')' inserts an extra ')'
@@ -50,6 +50,8 @@
  *   need to consider a solution for this...
  *
  * Done:
+ * ! Change loader to convert everything to UTF32 - for fast rendering
+ * ! Need a new text renderer -> handling of unicode
  * ! Cursor sometimes indicates wrong line but gutter-indicator seems correct!
  * ! Select/Copy/Paste are wrong - scrolling makes them non-reliable...
  * ! File monitoring on Linux

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,10 @@ to the terminal.
 
 # Building
 The build is driven by CMake.
+
+Cmake will check if 'ext/' contains the dependencies (which are considered local) and check them out if they don't
+exists. Other dependencies are considered system dependencies and you need to install them.
+
 If it doesn't build out of box, check that stuff is installed properly and that CMakeLists.txt points to the dependencies
 in the proper way. You are looking for a bunch of:
 ```
@@ -61,7 +65,8 @@ in the proper way. You are looking for a bunch of:
     set(SDL_HOME /usr/local)
     set(DUKTAPE_HOME ext/duktape-2.7.0/src)
     set(DUKTAPE_EXTRAS ext/duktape-2.7.0/extras)
-    set(DUKGLUE_HOME ext/dukglue)    
+    set(DUKGLUE_HOME ext/dukglue) 
+    set(FMT_HOME ext/fmt)   
 ```
 
 ## Dependencies
@@ -73,6 +78,7 @@ in the proper way. You are looking for a bunch of:
 - dukglue (just take master), https://github.com/Aloshi/dukglue - clone this to editor/ext/dukglue
 - logger, https://github.com/gnilk/logger - clone this to editor/ext/logger
 - stb, https://github.com/nothings/stb, ttf and rect_pack (already added to my repo)
+- fmtlib, https://github.com/fmtlib/fmt, CPP string formatting with U32/U16/U8 support
 
 
 - libSDL, ncurses, yaml, nlohmann you can download and install the packages. 

--- a/src/Core/ClipBoard.cpp
+++ b/src/Core/ClipBoard.cpp
@@ -109,7 +109,7 @@ void ClipBoard::ClipBoardItem::PasteToBuffer(TextBuffer::Ref dstBuffer, const Po
         }
         auto substr = data[0].substr(start.x, dx);
         if (dstBuffer->NumLines() == 0) {
-            dstBuffer->AddLine(substr.data());
+            dstBuffer->AddLineUTF8(substr.data());
         } else if (ptWhere.x > dstBuffer->LineAt(idxLine)->Length()) {
             dstBuffer->LineAt(idxLine)->Append(substr);
         } else {

--- a/src/Core/ClipBoard.cpp
+++ b/src/Core/ClipBoard.cpp
@@ -5,7 +5,7 @@
 #include "ClipBoard.h"
 #include <string>
 #include <sstream>
-
+#include "UnicodeHelper.h"
 using namespace gedit;
 
 bool ClipBoard::CopyFromBuffer(TextBuffer::Ref srcBuffer, const Point &ptStart, const Point &ptEnd) {
@@ -52,8 +52,6 @@ void ClipBoard::Dump() {
     }
 }
 
-
-
 ClipBoard::ClipBoardItem::Ref ClipBoard::ClipBoardItem::Create(TextBuffer::Ref srcBuffer, const Point &ptStart, const Point &ptEnd) {
     auto item = std::make_shared<ClipBoardItem>();
     item->start = ptStart;
@@ -61,6 +59,7 @@ ClipBoard::ClipBoardItem::Ref ClipBoard::ClipBoardItem::Create(TextBuffer::Ref s
     item->CopyFromBuffer(srcBuffer);
     return item;
 }
+
 ClipBoard::ClipBoardItem::Ref ClipBoard::ClipBoardItem::CreateExternal(const char *srcData) {
     auto item = std::make_shared<ClipBoardItem>();
     item->isExternal = true;
@@ -80,7 +79,7 @@ void ClipBoard::ClipBoardItem::CopyFromBuffer(TextBuffer::Ref srcBuffer) {
     // We simply copy the full lines and when we restore it we read with x-offset handling...
     for(int i=start.y;i<yEnd;i++) {
         auto line = srcBuffer->LineAt(i);
-        data.push_back(std::string(line->Buffer()));
+        data.push_back(std::u32string(line->Buffer()));
     }
 }
 
@@ -88,7 +87,10 @@ void ClipBoard::ClipBoardItem::CopyFromExternal(const char *srcData) {
     std::stringstream strStream(srcData);
     std::string line;
     while(std::getline(strStream, line)) {
-        data.push_back(line);
+        std::u32string tmp;
+        if (UnicodeHelper::ConvertUTF8ToUTF32String(tmp, line)) {
+            data.push_back(tmp);
+        }
     }
 }
 
@@ -103,13 +105,13 @@ void ClipBoard::ClipBoardItem::PasteToBuffer(TextBuffer::Ref dstBuffer, const Po
     size_t idxData = 0;
 
     if ((start.x != 0) || (ptWhere.x != 0)) {
-        int dx = data[0].length() - start.x;
+        auto dx = data[0].length() - start.x;
         if (start.y == end.y) {
             dx = end.x - start.x;
         }
         auto substr = data[0].substr(start.x, dx);
         if (dstBuffer->NumLines() == 0) {
-            dstBuffer->AddLineUTF8(substr.data());
+            dstBuffer->AddLine(substr);
         } else if (ptWhere.x > dstBuffer->LineAt(idxLine)->Length()) {
             dstBuffer->LineAt(idxLine)->Append(substr);
         } else {

--- a/src/Core/ClipBoard.h
+++ b/src/Core/ClipBoard.h
@@ -34,7 +34,7 @@ namespace gedit {
             }
             size_t GetByteSize();
 
-            const std::vector<std::string> &GetData() {
+            const std::vector<std::u32string> &GetData() {
                 return data;
             }
             const Point &GetStart() {
@@ -55,7 +55,7 @@ namespace gedit {
             Point start = {};
             Point end = {};
             bool isExternal = false;
-            std::vector<std::string> data;
+            std::vector<std::u32string> data;
         };
     public:
         using OnUpdateDelegate = std::function<void(ClipBoard::ClipBoardItem::Ref item)>;

--- a/src/Core/Controllers/CommandController.cpp
+++ b/src/Core/Controllers/CommandController.cpp
@@ -21,7 +21,7 @@ void CommandController::Begin() {
 
     NewLine();
 
-    terminal.SetStdoutDelegate([this](std::string &output) {
+    terminal.SetStdoutDelegate([this](std::u32string &output) {
         WriteLine(output);
     });
 
@@ -39,7 +39,7 @@ void CommandController::NewLine() {
     }
 }
 
-void CommandController::WriteLine(const std::string &str) {
+void CommandController::WriteLine(const std::u32string &str) {
     // Let's append to current line and commit to history buffer
     currentLine->Append(str);
     historyBuffer.push_back(currentLine);
@@ -61,7 +61,7 @@ void CommandController::CommitLine() {
     // When a line is commited, it is history..
     historyBuffer.push_back(currentLine);
 
-    std::string cmdLine(currentLine->Buffer().data());
+    std::u32string cmdLine(currentLine->Buffer());
     if (cmdLine.size() < 1) {
         NewLine();
         return;
@@ -75,14 +75,14 @@ void CommandController::CommitLine() {
     TryExecuteShellCmd(cmdLine);
 }
 
-void CommandController::TryExecuteShellCmd(std::string &cmdline) {
+void CommandController::TryExecuteShellCmd(std::u32string &cmdline) {
     // Just push this to the shell "process"...
     strutil::trim(cmdline);
     logger->Debug("Trying shell: %s", cmdline.c_str());
 
     // Make sure to append CRLN otherwise the shell won't execute...
     // Should this be configurable??
-    cmdline += "\n";
+    cmdline += U"\n";
     terminal.SendCmd(cmdline);
 
     // We have executed the shell - even though it might require a long time to execute this is needed

--- a/src/Core/Controllers/CommandController.h
+++ b/src/Core/Controllers/CommandController.h
@@ -38,11 +38,12 @@ namespace gedit {
 
 
         // This is from IOutputConsole - which is/was used by the expermintal API
-        void WriteLine(const std::string &str);
+        void WriteLine(const std::u32string &str);
+
 
     protected:
         void NewLine();
-        void TryExecuteShellCmd(std::string &cmdline);
+        void TryExecuteShellCmd(std::u32string &cmdline);
 
 
         void TestShowDialog();

--- a/src/Core/Controllers/QuickCommandController.h
+++ b/src/Core/Controllers/QuickCommandController.h
@@ -27,10 +27,10 @@ namespace gedit {
         bool HandleAction(const KeyPressAction &kpAction) override;
         void HandleKeyPress(const KeyPress &keyPress) override;
 
-        const std::string_view GetCmdLine() const {
+        const std::u32string_view GetCmdLine() const {
             return cmdInput->Buffer();
         }
-        const std::string &GetPrompt() const {
+        const std::u32string &GetPrompt() const {
             return prompt;
         }
         const Cursor &GetCursor() const {
@@ -41,7 +41,7 @@ namespace gedit {
         bool HandleActionInSearch(const KeyPressAction &kpAction);
         bool HandleActionInCmdLetState(const KeyPressAction &kpAction);
         void DoLeaveOnSuccess();
-        void SearchInActiveEditorModel(const std::string &searchItem);
+        void SearchInActiveEditorModel(const std::u32string &searchItem);
         void NextSearchResult();
         void PrevSearchResult();
     private:
@@ -51,8 +51,8 @@ namespace gedit {
         BaseController cmdInputBaseController;
         Cursor cursor = {};
         Line::Ref cmdInput = nullptr;
-        std::vector<std::string> searchHistory;
-        std::string prompt = "C";
+        std::vector<std::u32string> searchHistory;
+        std::u32string prompt = U"C";
         State state = QuickCmdState;
     };
 }

--- a/src/Core/ConvertUTF.c
+++ b/src/Core/ConvertUTF.c
@@ -1,0 +1,539 @@
+/*
+ * Copyright 2001-2004 Unicode, Inc.
+ * 
+ * Disclaimer
+ * 
+ * This source code is provided as is by Unicode, Inc. No claims are
+ * made as to fitness for any particular purpose. No warranties of any
+ * kind are expressed or implied. The recipient agrees to determine
+ * applicability of information provided. If this file has been
+ * purchased on magnetic or optical media from Unicode, Inc., the
+ * sole remedy for any claim will be exchange of defective media
+ * within 90 days of receipt.
+ * 
+ * Limitations on Rights to Redistribute This Code
+ * 
+ * Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard, and to make copies of this file in any form
+ * for internal or external distribution as long as this notice
+ * remains attached.
+ */
+
+/* ---------------------------------------------------------------------
+
+    Conversions between UTF32, UTF-16, and UTF-8. Source code file.
+    Author: Mark E. Davis, 1994.
+    Rev History: Rick McGowan, fixes & updates May 2001.
+    Sept 2001: fixed const & error conditions per
+	mods suggested by S. Parent & A. Lillich.
+    June 2002: Tim Dodd added detection and handling of incomplete
+	source sequences, enhanced error detection, added casts
+	to eliminate compiler warnings.
+    July 2003: slight mods to back out aggressive FFFE detection.
+    Jan 2004: updated switches in from-UTF8 conversions.
+    Oct 2004: updated to use UNI_MAX_LEGAL_UTF32 in UTF-32 conversions.
+
+    See the header file "ConvertUTF.h" for complete documentation.
+
+------------------------------------------------------------------------ */
+
+
+#include "ConvertUTF.h"
+#ifdef CVTUTF_DEBUG
+#include <stdio.h>
+#endif
+
+static const int halfShift  = 10; /* used for shifting by 10 bits */
+
+static const UTF32 halfBase = 0x0010000UL;
+static const UTF32 halfMask = 0x3FFUL;
+
+#define UNI_SUR_HIGH_START  (UTF32)0xD800
+#define UNI_SUR_HIGH_END    (UTF32)0xDBFF
+#define UNI_SUR_LOW_START   (UTF32)0xDC00
+#define UNI_SUR_LOW_END     (UTF32)0xDFFF
+#define false	   0
+#define true	    1
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF32toUTF16 (
+	const UTF32** sourceStart, const UTF32* sourceEnd, 
+	UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF32* source = *sourceStart;
+    UTF16* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch;
+	if (target >= targetEnd) {
+	    result = targetExhausted; break;
+	}
+	ch = *source++;
+	if (ch <= UNI_MAX_BMP) { /* Target is a character <= 0xFFFF */
+	    /* UTF-16 surrogate values are illegal in UTF-32; 0xffff or 0xfffe are both reserved values */
+	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+		if (flags == strictConversion) {
+		    --source; /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		} else {
+		    *target++ = UNI_REPLACEMENT_CHAR;
+		}
+	    } else {
+		*target++ = (UTF16)ch; /* normal case */
+	    }
+	} else if (ch > UNI_MAX_LEGAL_UTF32) {
+	    if (flags == strictConversion) {
+		result = sourceIllegal;
+	    } else {
+		*target++ = UNI_REPLACEMENT_CHAR;
+	    }
+	} else {
+	    /* target is a character in range 0xFFFF - 0x10FFFF. */
+	    if (target + 1 >= targetEnd) {
+		--source; /* Back up source pointer! */
+		result = targetExhausted; break;
+	    }
+	    ch -= halfBase;
+	    *target++ = (UTF16)((ch >> halfShift) + UNI_SUR_HIGH_START);
+	    *target++ = (UTF16)((ch & halfMask) + UNI_SUR_LOW_START);
+	}
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF16toUTF32 (
+	const UTF16** sourceStart, const UTF16* sourceEnd, 
+	UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF16* source = *sourceStart;
+    UTF32* target = *targetStart;
+    UTF32 ch, ch2;
+    while (source < sourceEnd) {
+	const UTF16* oldSource = source; /*  In case we have to back up because of target overflow. */
+	ch = *source++;
+	/* If we have a surrogate pair, convert to UTF32 first. */
+	if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
+	    /* If the 16 bits following the high surrogate are in the source buffer... */
+	    if (source < sourceEnd) {
+		ch2 = *source;
+		/* If it's a low surrogate, convert to UTF32. */
+		if (ch2 >= UNI_SUR_LOW_START && ch2 <= UNI_SUR_LOW_END) {
+		    ch = ((ch - UNI_SUR_HIGH_START) << halfShift)
+			+ (ch2 - UNI_SUR_LOW_START) + halfBase;
+		    ++source;
+		} else if (flags == strictConversion) { /* it's an unpaired high surrogate */
+		    --source; /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		}
+	    } else { /* We don't have the 16 bits following the high surrogate. */
+		--source; /* return to the high surrogate */
+		result = sourceExhausted;
+		break;
+	    }
+	} else if (flags == strictConversion) {
+	    /* UTF-16 surrogate values are illegal in UTF-32 */
+	    if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
+		--source; /* return to the illegal value itself */
+		result = sourceIllegal;
+		break;
+	    }
+	}
+	if (target >= targetEnd) {
+	    source = oldSource; /* Back up source pointer! */
+	    result = targetExhausted; break;
+	}
+	*target++ = ch;
+    }
+    *sourceStart = source;
+    *targetStart = target;
+#ifdef CVTUTF_DEBUG
+if (result == sourceIllegal) {
+    fprintf(stderr, "ConvertUTF16toUTF32 illegal seq 0x%04x,%04x\n", ch, ch2);
+    fflush(stderr);
+}
+#endif
+    return result;
+}
+
+/* --------------------------------------------------------------------- */
+
+/*
+ * Index into the table below with the first byte of a UTF-8 sequence to
+ * get the number of trailing bytes that are supposed to follow it.
+ * Note that *legal* UTF-8 values can't have 4 or 5-bytes. The table is
+ * left as-is for anyone who may want to do such conversion, which was
+ * allowed in earlier algorithms.
+ */
+static const char trailingBytesForUTF8[256] = {
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
+};
+
+/*
+ * Magic values subtracted from a buffer value during UTF8 conversion.
+ * This table contains as many values as there might be trailing bytes
+ * in a UTF-8 sequence.
+ */
+static const UTF32 offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL, 
+		     0x03C82080UL, 0xFA082080UL, 0x82082080UL };
+
+/*
+ * Once the bits are split out into bytes of UTF-8, this is a mask OR-ed
+ * into the first byte, depending on how many bytes follow.  There are
+ * as many entries in this table as there are UTF-8 sequence types.
+ * (I.e., one byte sequence, two byte... etc.). Remember that sequencs
+ * for *legal* UTF-8 will be 4 or fewer bytes total.
+ */
+static const UTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+/* --------------------------------------------------------------------- */
+
+/* The interface converts a whole buffer to avoid function-call overhead.
+ * Constants have been gathered. Loops & conditionals have been removed as
+ * much as possible for efficiency, in favor of drop-through switches.
+ * (See "Note A" at the bottom of the file for equivalent code.)
+ * If your compiler supports it, the "isLegalUTF8" call can be turned
+ * into an inline function.
+ */
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF16toUTF8 (
+	const UTF16** sourceStart, const UTF16* sourceEnd, 
+	UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF16* source = *sourceStart;
+    UTF8* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch;
+	unsigned short bytesToWrite = 0;
+	const UTF32 byteMask = 0xBF;
+	const UTF32 byteMark = 0x80; 
+	const UTF16* oldSource = source; /* In case we have to back up because of target overflow. */
+	ch = *source++;
+	/* If we have a surrogate pair, convert to UTF32 first. */
+	if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
+	    /* If the 16 bits following the high surrogate are in the source buffer... */
+	    if (source < sourceEnd) {
+		UTF32 ch2 = *source;
+		/* If it's a low surrogate, convert to UTF32. */
+		if (ch2 >= UNI_SUR_LOW_START && ch2 <= UNI_SUR_LOW_END) {
+		    ch = ((ch - UNI_SUR_HIGH_START) << halfShift)
+			+ (ch2 - UNI_SUR_LOW_START) + halfBase;
+		    ++source;
+		} else if (flags == strictConversion) { /* it's an unpaired high surrogate */
+		    --source; /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		}
+	    } else { /* We don't have the 16 bits following the high surrogate. */
+		--source; /* return to the high surrogate */
+		result = sourceExhausted;
+		break;
+	    }
+	} else if (flags == strictConversion) {
+	    /* UTF-16 surrogate values are illegal in UTF-32 */
+	    if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
+		--source; /* return to the illegal value itself */
+		result = sourceIllegal;
+		break;
+	    }
+	}
+	/* Figure out how many bytes the result will require */
+	if (ch < (UTF32)0x80) {	     bytesToWrite = 1;
+	} else if (ch < (UTF32)0x800) {     bytesToWrite = 2;
+	} else if (ch < (UTF32)0x10000) {   bytesToWrite = 3;
+	} else if (ch < (UTF32)0x110000) {  bytesToWrite = 4;
+	} else {			    bytesToWrite = 3;
+					    ch = UNI_REPLACEMENT_CHAR;
+	}
+
+	target += bytesToWrite;
+	if (target > targetEnd) {
+	    source = oldSource; /* Back up source pointer! */
+	    target -= bytesToWrite; result = targetExhausted; break;
+	}
+	switch (bytesToWrite) { /* note: everything falls through. */
+	    case 4: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 3: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 2: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 1: *--target =  (UTF8)(ch | firstByteMark[bytesToWrite]);
+	}
+	target += bytesToWrite;
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+/* --------------------------------------------------------------------- */
+
+/*
+ * Utility routine to tell whether a sequence of bytes is legal UTF-8.
+ * This must be called with the length pre-determined by the first byte.
+ * If not calling this from ConvertUTF8to*, then the length can be set by:
+ *  length = trailingBytesForUTF8[*source]+1;
+ * and the sequence is illegal right away if there aren't that many bytes
+ * available.
+ * If presented with a length > 4, this returns false.  The Unicode
+ * definition of UTF-8 goes up to 4-byte sequences.
+ */
+
+static Boolean isLegalUTF8(const UTF8 *source, int length) {
+    UTF8 a;
+    const UTF8 *srcptr = source+length;
+    switch (length) {
+    default: return false;
+	/* Everything else falls through when "true"... */
+    case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    case 2: if ((a = (*--srcptr)) > 0xBF) return false;
+
+	switch (*source) {
+	    /* no fall-through in this inner switch */
+	    case 0xE0: if (a < 0xA0) return false; break;
+	    case 0xED: if (a > 0x9F) return false; break;
+	    case 0xF0: if (a < 0x90) return false; break;
+	    case 0xF4: if (a > 0x8F) return false; break;
+	    default:   if (a < 0x80) return false;
+	}
+
+    case 1: if (*source >= 0x80 && *source < 0xC2) return false;
+    }
+    if (*source > 0xF4) return false;
+    return true;
+}
+
+/* --------------------------------------------------------------------- */
+
+/*
+ * Exported function to return whether a UTF-8 sequence is legal or not.
+ * This is not used here; it's just exported.
+ */
+Boolean isLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd) {
+    int length = trailingBytesForUTF8[*source]+1;
+    if (source+length > sourceEnd) {
+	return false;
+    }
+    return isLegalUTF8(source, length);
+}
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF8toUTF16 (
+	const UTF8** sourceStart, const UTF8* sourceEnd, 
+	UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF8* source = *sourceStart;
+    UTF16* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch = 0;
+	unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+	if (source + extraBytesToRead >= sourceEnd) {
+	    result = sourceExhausted; break;
+	}
+	/* Do this check whether lenient or strict */
+	if (! isLegalUTF8(source, extraBytesToRead+1)) {
+	    result = sourceIllegal;
+	    break;
+	}
+	/*
+	 * The cases all fall through. See "Note A" below.
+	 */
+	switch (extraBytesToRead) {
+	    case 5: ch += *source++; ch <<= 6; /* remember, illegal UTF-8 */
+	    case 4: ch += *source++; ch <<= 6; /* remember, illegal UTF-8 */
+	    case 3: ch += *source++; ch <<= 6;
+	    case 2: ch += *source++; ch <<= 6;
+	    case 1: ch += *source++; ch <<= 6;
+	    case 0: ch += *source++;
+	}
+	ch -= offsetsFromUTF8[extraBytesToRead];
+
+	if (target >= targetEnd) {
+	    source -= (extraBytesToRead+1); /* Back up source pointer! */
+	    result = targetExhausted; break;
+	}
+	if (ch <= UNI_MAX_BMP) { /* Target is a character <= 0xFFFF */
+	    /* UTF-16 surrogate values are illegal in UTF-32 */
+	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+		if (flags == strictConversion) {
+		    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		} else {
+		    *target++ = UNI_REPLACEMENT_CHAR;
+		}
+	    } else {
+		*target++ = (UTF16)ch; /* normal case */
+	    }
+	} else if (ch > UNI_MAX_UTF16) {
+	    if (flags == strictConversion) {
+		result = sourceIllegal;
+		source -= (extraBytesToRead+1); /* return to the start */
+		break; /* Bail out; shouldn't continue */
+	    } else {
+		*target++ = UNI_REPLACEMENT_CHAR;
+	    }
+	} else {
+	    /* target is a character in range 0xFFFF - 0x10FFFF. */
+	    if (target + 1 >= targetEnd) {
+		source -= (extraBytesToRead+1); /* Back up source pointer! */
+		result = targetExhausted; break;
+	    }
+	    ch -= halfBase;
+	    *target++ = (UTF16)((ch >> halfShift) + UNI_SUR_HIGH_START);
+	    *target++ = (UTF16)((ch & halfMask) + UNI_SUR_LOW_START);
+	}
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF32toUTF8 (
+	const UTF32** sourceStart, const UTF32* sourceEnd, 
+	UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF32* source = *sourceStart;
+    UTF8* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch;
+	unsigned short bytesToWrite = 0;
+	const UTF32 byteMask = 0xBF;
+	const UTF32 byteMark = 0x80; 
+	ch = *source++;
+	if (flags == strictConversion ) {
+	    /* UTF-16 surrogate values are illegal in UTF-32 */
+	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+		--source; /* return to the illegal value itself */
+		result = sourceIllegal;
+		break;
+	    }
+	}
+	/*
+	 * Figure out how many bytes the result will require. Turn any
+	 * illegally large UTF32 things (> Plane 17) into replacement chars.
+	 */
+	if (ch < (UTF32)0x80) {	     bytesToWrite = 1;
+	} else if (ch < (UTF32)0x800) {     bytesToWrite = 2;
+	} else if (ch < (UTF32)0x10000) {   bytesToWrite = 3;
+	} else if (ch <= UNI_MAX_LEGAL_UTF32) {  bytesToWrite = 4;
+	} else {			    bytesToWrite = 3;
+					    ch = UNI_REPLACEMENT_CHAR;
+					    result = sourceIllegal;
+	}
+	
+	target += bytesToWrite;
+	if (target > targetEnd) {
+	    --source; /* Back up source pointer! */
+	    target -= bytesToWrite; result = targetExhausted; break;
+	}
+	switch (bytesToWrite) { /* note: everything falls through. */
+	    case 4: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 3: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 2: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+	    case 1: *--target = (UTF8) (ch | firstByteMark[bytesToWrite]);
+	}
+	target += bytesToWrite;
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+/* --------------------------------------------------------------------- */
+
+ConversionResult ConvertUTF8toUTF32 (
+	const UTF8** sourceStart, const UTF8* sourceEnd, 
+	UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF8* source = *sourceStart;
+    UTF32* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch = 0;
+	unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+	if (source + extraBytesToRead >= sourceEnd) {
+	    result = sourceExhausted; break;
+	}
+	/* Do this check whether lenient or strict */
+	if (! isLegalUTF8(source, extraBytesToRead+1)) {
+	    result = sourceIllegal;
+	    break;
+	}
+	/*
+	 * The cases all fall through. See "Note A" below.
+	 */
+	switch (extraBytesToRead) {
+	    case 5: ch += *source++; ch <<= 6;
+	    case 4: ch += *source++; ch <<= 6;
+	    case 3: ch += *source++; ch <<= 6;
+	    case 2: ch += *source++; ch <<= 6;
+	    case 1: ch += *source++; ch <<= 6;
+	    case 0: ch += *source++;
+	}
+	ch -= offsetsFromUTF8[extraBytesToRead];
+
+	if (target >= targetEnd) {
+	    source -= (extraBytesToRead+1); /* Back up the source pointer! */
+	    result = targetExhausted; break;
+	}
+	if (ch <= UNI_MAX_LEGAL_UTF32) {
+	    /*
+	     * UTF-16 surrogate values are illegal in UTF-32, and anything
+	     * over Plane 17 (> 0x10FFFF) is illegal.
+	     */
+	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+		if (flags == strictConversion) {
+		    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		} else {
+		    *target++ = UNI_REPLACEMENT_CHAR;
+		}
+	    } else {
+		*target++ = ch;
+	    }
+	} else { /* i.e., ch > UNI_MAX_LEGAL_UTF32 */
+	    result = sourceIllegal;
+	    *target++ = UNI_REPLACEMENT_CHAR;
+	}
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+/* ---------------------------------------------------------------------
+
+    Note A.
+    The fall-through switches in UTF-8 reading code save a
+    temp variable, some decrements & conditionals.  The switches
+    are equivalent to the following loop:
+	{
+	    int tmpBytesToRead = extraBytesToRead+1;
+	    do {
+		ch += *source++;
+		--tmpBytesToRead;
+		if (tmpBytesToRead) ch <<= 6;
+	    } while (tmpBytesToRead > 0);
+	}
+    In UTF-8 writing code, the switches on "bytesToWrite" are
+    similarly unrolled loops.
+
+   --------------------------------------------------------------------- */

--- a/src/Core/ConvertUTF.h
+++ b/src/Core/ConvertUTF.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2001-2004 Unicode, Inc.
+ * 
+ * Disclaimer
+ * 
+ * This source code is provided as is by Unicode, Inc. No claims are
+ * made as to fitness for any particular purpose. No warranties of any
+ * kind are expressed or implied. The recipient agrees to determine
+ * applicability of information provided. If this file has been
+ * purchased on magnetic or optical media from Unicode, Inc., the
+ * sole remedy for any claim will be exchange of defective media
+ * within 90 days of receipt.
+ * 
+ * Limitations on Rights to Redistribute This Code
+ * 
+ * Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard, and to make copies of this file in any form
+ * for internal or external distribution as long as this notice
+ * remains attached.
+ */
+
+/* ---------------------------------------------------------------------
+
+    Conversions between UTF32, UTF-16, and UTF-8.  Header file.
+
+    Several funtions are included here, forming a complete set of
+    conversions between the three formats.  UTF-7 is not included
+    here, but is handled in a separate source file.
+
+    Each of these routines takes pointers to input buffers and output
+    buffers.  The input buffers are const.
+
+    Each routine converts the text between *sourceStart and sourceEnd,
+    putting the result into the buffer between *targetStart and
+    targetEnd. Note: the end pointers are *after* the last item: e.g. 
+    *(sourceEnd - 1) is the last item.
+
+    The return result indicates whether the conversion was successful,
+    and if not, whether the problem was in the source or target buffers.
+    (Only the first encountered problem is indicated.)
+
+    After the conversion, *sourceStart and *targetStart are both
+    updated to point to the end of last text successfully converted in
+    the respective buffers.
+
+    Input parameters:
+	sourceStart - pointer to a pointer to the source buffer.
+		The contents of this are modified on return so that
+		it points at the next thing to be converted.
+	targetStart - similarly, pointer to pointer to the target buffer.
+	sourceEnd, targetEnd - respectively pointers to the ends of the
+		two buffers, for overflow checking only.
+
+    These conversion functions take a ConversionFlags argument. When this
+    flag is set to strict, both irregular sequences and isolated surrogates
+    will cause an error.  When the flag is set to lenient, both irregular
+    sequences and isolated surrogates are converted.
+
+    Whether the flag is strict or lenient, all illegal sequences will cause
+    an error return. This includes sequences such as: <F4 90 80 80>, <C0 80>,
+    or <A0> in UTF-8, and values above 0x10FFFF in UTF-32. Conformant code
+    must check for illegal sequences.
+
+    When the flag is set to lenient, characters over 0x10FFFF are converted
+    to the replacement character; otherwise (when the flag is set to strict)
+    they constitute an error.
+
+    Output parameters:
+	The value "sourceIllegal" is returned from some routines if the input
+	sequence is malformed.  When "sourceIllegal" is returned, the source
+	value will point to the illegal value that caused the problem. E.g.,
+	in UTF-8 when a sequence is malformed, it points to the start of the
+	malformed sequence.  
+
+    Author: Mark E. Davis, 1994.
+    Rev History: Rick McGowan, fixes & updates May 2001.
+		 Fixes & updates, Sept 2001.
+
+------------------------------------------------------------------------ */
+
+/* ---------------------------------------------------------------------
+    The following 4 definitions are compiler-specific.
+    The C standard does not guarantee that wchar_t has at least
+    16 bits, so wchar_t is no less portable than unsigned short!
+    All should be unsigned values to avoid sign extension during
+    bit mask & shift operations.
+------------------------------------------------------------------------ */
+
+typedef unsigned int	UTF32;	/* at least 32 bits */
+typedef unsigned short	UTF16;	/* at least 16 bits */
+typedef unsigned char	UTF8;	/* typically 8 bits */
+typedef unsigned char	Boolean; /* 0 or 1 */
+
+/* Some fundamental constants */
+#define UNI_REPLACEMENT_CHAR (UTF32)0x0000FFFD
+#define UNI_MAX_BMP (UTF32)0x0000FFFF
+#define UNI_MAX_UTF16 (UTF32)0x0010FFFF
+#define UNI_MAX_UTF32 (UTF32)0x7FFFFFFF
+#define UNI_MAX_LEGAL_UTF32 (UTF32)0x0010FFFF
+#define UNI_MAX_UTF8_BYTES_PER_CODE_POINT 4
+
+typedef enum {
+	conversionOK, 		/* conversion successful */
+	sourceExhausted,	/* partial character in source, but hit end */
+	targetExhausted,	/* insuff. room in target for conversion */
+	sourceIllegal		/* source sequence is illegal/malformed */
+} ConversionResult;
+
+typedef enum {
+	strictConversion = 0,
+	lenientConversion
+} ConversionFlags;
+
+/* This is for C++ and does no harm in C */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ConversionResult ConvertUTF8toUTF16 (
+		const UTF8** sourceStart, const UTF8* sourceEnd, 
+		UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
+
+ConversionResult ConvertUTF16toUTF8 (
+		const UTF16** sourceStart, const UTF16* sourceEnd, 
+		UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
+		
+ConversionResult ConvertUTF8toUTF32 (
+		const UTF8** sourceStart, const UTF8* sourceEnd, 
+		UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
+
+ConversionResult ConvertUTF32toUTF8 (
+		const UTF32** sourceStart, const UTF32* sourceEnd, 
+		UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
+		
+ConversionResult ConvertUTF16toUTF32 (
+		const UTF16** sourceStart, const UTF16* sourceEnd, 
+		UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
+
+ConversionResult ConvertUTF32toUTF16 (
+		const UTF32** sourceStart, const UTF32* sourceEnd, 
+		UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
+
+Boolean isLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* --------------------------------------------------------------------- */

--- a/src/Core/DrawContext.h
+++ b/src/Core/DrawContext.h
@@ -90,8 +90,6 @@ namespace gedit {
 
         virtual void DrawStringAt(int x, int y, const std::u32string &str) const {}
         virtual void DrawStringWithAttributesAt(int x, int y, kTextAttributes attrib, const std::u32string &str) const {}
-        virtual void DrawStringWithAttributesAndColAt(int x, int y, kTextAttributes attrib, int idxColor, const std::u32string &str) const {}
-
 
         __inline void SetBGColor(const ColorRGBA &newBackgroundColor) {
             const_cast<DrawContext *>(this)->bgColor = newBackgroundColor;

--- a/src/Core/DrawContext.h
+++ b/src/Core/DrawContext.h
@@ -88,6 +88,11 @@ namespace gedit {
         virtual void DrawStringWithAttributesAt(int x, int y, kTextAttributes attrib, const char *str) const {}
         virtual void DrawStringWithAttributesAndColAt(int x, int y, kTextAttributes attrib, int idxColor, const char *str) const {}
 
+        virtual void DrawStringAt(int x, int y, const std::u32string &str) const {}
+        virtual void DrawStringWithAttributesAt(int x, int y, kTextAttributes attrib, const std::u32string &str) const {}
+        virtual void DrawStringWithAttributesAndColAt(int x, int y, kTextAttributes attrib, int idxColor, const std::u32string &str) const {}
+
+
         __inline void SetBGColor(const ColorRGBA &newBackgroundColor) {
             const_cast<DrawContext *>(this)->bgColor = newBackgroundColor;
             OnColorUpdate();

--- a/src/Core/Editor.h
+++ b/src/Core/Editor.h
@@ -144,8 +144,8 @@ namespace gedit {
             return theme;
         }
 
-        const std::string &GetAppName();
-        const std::string &GetVersion();
+        const std::u32string &GetAppName();
+        const std::u32string &GetVersion();
 
 
         EditorModel::Ref OpenModelFromWorkspace(Workspace::Node::Ref workspaceNode);

--- a/src/Core/EditorModel.cpp
+++ b/src/Core/EditorModel.cpp
@@ -44,7 +44,7 @@ void EditorModel::CommentSelectionOrLine() {
 }
 
 // This is a little naive and I should probably spin it of to a specific thread
-size_t EditorModel::SearchFor(const std::string &searchItem) {
+size_t EditorModel::SearchFor(const std::u32string &searchItem) {
 
     auto tStart = std::chrono::steady_clock::now();
 

--- a/src/Core/EditorModel.h
+++ b/src/Core/EditorModel.h
@@ -164,7 +164,7 @@ namespace gedit {
         void DeleteSelection();
         void CommentSelectionOrLine();
 
-        size_t SearchFor(const std::string &searchItem);
+        size_t SearchFor(const std::u32string &searchItem);
         void ClearSearchResults();
         bool HaveSearchResults() {
             return !searchResults.empty();

--- a/src/Core/JSEngine/Modules/ConsoleAPIWrapper.cpp
+++ b/src/Core/JSEngine/Modules/ConsoleAPIWrapper.cpp
@@ -54,6 +54,7 @@ duk_ret_t ConsoleAPIWrapper::WriteLine(duk_context *ctx) {
 
 void ConsoleAPIWrapper::SendToConsole(const char *str) {
     auto console = RuntimeConfig::Instance().OutputConsole();
-    console->WriteLine(str);
+    auto str32 = UnicodeHelper::utf8to32(str);
+    console->WriteLine(str32);
 }
 

--- a/src/Core/KeyPress.h
+++ b/src/Core/KeyPress.h
@@ -16,13 +16,12 @@ namespace gedit {
         bool isSpecialKey = false;
         Keyboard::HWKeyEvent hwEvent;
         uint8_t modifiers;
-        int key;
+        char32_t key;
         int specialKey;
 
-        // Human readables..  NOTE: we don't support unicode..  I'm old-skool...
         bool IsHumanReadable() const {
             if (isKeyValid) {
-                if ((key > 31) && (key < 127)) {
+                if (key >= 32) {
                     return true;
                 }
             }

--- a/src/Core/Language/LangLineTokenizer.cpp
+++ b/src/Core/Language/LangLineTokenizer.cpp
@@ -115,6 +115,9 @@ void LangLineTokenizer::ParseLine(const Line::Ref l, int &nextIndent) {
     l->SetStateStackDepth((int)stateStack.size());
 
     auto asciiLine = UnicodeHelper::utf32toascii(l->Buffer());
+    if (asciiLine.empty()) {
+        return;
+    }
     ParseLineWithCurrentState(tokens, asciiLine.c_str());
 
     // Indent handling

--- a/src/Core/Language/LangLineTokenizer.cpp
+++ b/src/Core/Language/LangLineTokenizer.cpp
@@ -113,7 +113,9 @@ void LangLineTokenizer::ParseLine(const Line::Ref l, int &nextIndent) {
     int currentIndentCounter = nextIndent;
 
     l->SetStateStackDepth((int)stateStack.size());
-    ParseLineWithCurrentState(tokens, l->Buffer().data());
+
+    auto asciiLine = UnicodeHelper::utf32toascii(l->Buffer());
+    ParseLineWithCurrentState(tokens, asciiLine.c_str());
 
     // Indent handling
     if (std::find_if(tokens.begin(), tokens.end(), [](LangToken &tClass)->bool {
@@ -163,7 +165,9 @@ void LangLineTokenizer::ParseLineFromStartState(std::string &lineStartState, Lin
     PushState(lineStartState.c_str());
     std::vector<LangToken> tokens;
 
-    ParseLineWithCurrentState(tokens, line->Buffer().data());
+    auto asciiLine = UnicodeHelper::utf32toascii(line->Buffer());
+
+    ParseLineWithCurrentState(tokens, asciiLine.c_str());
     LangToken::ToLineAttrib(line->Attributes(), tokens);
     PopState();
 }

--- a/src/Core/Language/LanguageBase.h
+++ b/src/Core/Language/LanguageBase.h
@@ -27,8 +27,8 @@ namespace gedit {
 
         // Implement this and setup the tokenizer
         virtual bool Initialize() { return false; }; // You should really implement this...
-        virtual const std::string &Identifier() {
-            static std::string noIdentifier = "default";
+        virtual const std::u32string &Identifier() {
+            static std::u32string noIdentifier = U"default";
             return noIdentifier;
         }
         LangLineTokenizer &Tokenizer() { return tokenizer; }

--- a/src/Core/Language/LanguageSupport/CPPLanguage.h
+++ b/src/Core/Language/LanguageSupport/CPPLanguage.h
@@ -24,8 +24,8 @@ namespace gedit {
 
 
         bool Initialize() override;
-        const std::string &Identifier() override {
-            static std::string cppIdentifier = "c/c++";
+        const std::u32string &Identifier() override {
+            static std::u32string cppIdentifier = U"c/c++";
             return cppIdentifier;
         }
 

--- a/src/Core/Language/LanguageSupport/DefaultLanguage.h
+++ b/src/Core/Language/LanguageSupport/DefaultLanguage.h
@@ -20,8 +20,8 @@ namespace gedit {
 
         bool Initialize() override;
 
-        const std::string &Identifier() override {
-            static std::string identifier = "default";
+        const std::u32string &Identifier() override {
+            static std::u32string identifier = U"default";
             return identifier;
         }
     };

--- a/src/Core/Language/LanguageSupport/JSONLanguage.h
+++ b/src/Core/Language/LanguageSupport/JSONLanguage.h
@@ -19,8 +19,8 @@ namespace gedit {
 
 
         bool Initialize() override;
-        const std::string &Identifier() override {
-            static std::string cppIdentifier = "json";
+        const std::u32string &Identifier() override {
+            static std::u32string cppIdentifier = U"json";
             return cppIdentifier;
         }
 

--- a/src/Core/Line.cpp
+++ b/src/Core/Line.cpp
@@ -246,3 +246,8 @@ bool Line::StartsWith(const std::u32string &prefix) {
     return strutil::startsWith(buffer, prefix);
 }
 
+const std::string Line::BufferAsUTF8() const {
+    return UnicodeHelper::utf32to8(buffer);
+}
+
+

--- a/src/Core/Line.cpp
+++ b/src/Core/Line.cpp
@@ -7,6 +7,7 @@
 
 #include "Core/StrUtil.h"
 #include "Core/Line.h"
+#include "Core/UnicodeHelper.h"
 
 using namespace gedit;
 
@@ -15,6 +16,8 @@ Line::Line() {
 }
 
 Line::Line(const char *data) {
+
+//    UnicodeHelper::ConvertUTF8ToUTF32(buffer, data);
     buffer = data;
     strutil::rtrim(buffer);
 }

--- a/src/Core/Line.cpp
+++ b/src/Core/Line.cpp
@@ -17,10 +17,17 @@ Line::Line() {
 
 Line::Line(const char *data) {
 
-//    UnicodeHelper::ConvertUTF8ToUTF32(buffer, data);
+    UnicodeHelper::ConvertUTF8ToUTF32String(buffer, data);
+    strutil::rtrim(buffer);
+//    buffer = data;
+//    strutil::rtrim(buffer);
+}
+
+Line::Line(const std::u32string &data) {
     buffer = data;
     strutil::rtrim(buffer);
 }
+
 
 Line::Ref Line::Create() {
     return std::make_shared<Line>();
@@ -31,6 +38,10 @@ Line::Ref Line::Create(const char *data) {
 Line::Ref Line::Create(const std::string &data) {
     return std::make_shared<Line>(data.c_str());
 }
+Line::Ref Line::Create(const std::u32string &data) {
+    return std::make_shared<Line>(data);
+}
+
 
 void Line::Lock() {
     lock.lock();
@@ -49,31 +60,31 @@ void Line::NotifyChangeHandler() {
 }
 
 void Line::Clear() {
-    buffer = "";
+    buffer = U"";
 }
 
 void Line::Append(int ch) {
     {
         std::lock_guard<std::mutex> guard(lock);
-        buffer += ch;
+        buffer += static_cast<char32_t >(ch);
     }
     NotifyChangeHandler();
 }
 
 void Line::Append(std::string_view &srcdata) {
-    {
-        std::lock_guard<std::mutex> guard(lock);
-        buffer += srcdata;
+    std::u32string tmp;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(tmp, srcdata.data())) {
+        return;
     }
-    NotifyChangeHandler();
+    Append(tmp);
 }
 
 void Line::Append(std::string &srcdata) {
-    {
-        std::lock_guard<std::mutex> guard(lock);
-        buffer += srcdata;
+    std::u32string tmp;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(tmp, srcdata)) {
+        return;
     }
-    NotifyChangeHandler();
+    Append(tmp);
 }
 
 void Line::Append(const std::string &srcdata) {
@@ -81,14 +92,33 @@ void Line::Append(const std::string &srcdata) {
 }
 
 void Line::Append(const char *srcdata) {
+    std::u32string tmp;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(tmp, srcdata)) {
+        return;
+    }
+    Append(tmp);
+}
+
+void Line::Append(const std::u32string &srcdata) {
     {
         std::lock_guard<std::mutex> guard(lock);
         buffer += srcdata;
     }
     NotifyChangeHandler();
 }
+
+void Line::Append(const std::u32string_view &srcdata) {
+    {
+        std::lock_guard<std::mutex> guard(lock);
+        buffer += srcdata;
+
+    }
+    NotifyChangeHandler();
+}
+
+
 void Line::Append(Line::Ref other) {
-    Append(other->Buffer().data());
+    Append(other->Buffer());
 }
 
 
@@ -101,22 +131,30 @@ void Line::Insert(int at, int ch) {
 }
 
 void Line::Insert(int at, const std::string_view &srcdata) {
+
+    std::u32string u32src;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(u32src, srcdata.data())) {
+        return;
+    }
+    Insert(at, u32src);
+}
+
+int Line::Insert(int at, int n, int ch) {
+    {
+        std::lock_guard<std::mutex> guard(lock);
+        buffer.insert(at, n, static_cast<char32_t>(ch));
+    }
+    NotifyChangeHandler();
+    return n;
+}
+
+void Line::Insert(int at, const std::u32string_view &srcdata) {
     {
         std::lock_guard<std::mutex> guard(lock);
         buffer.insert(at, srcdata);
     }
     NotifyChangeHandler();
 }
-
-int Line::Insert(int at, int n, int ch) {
-    {
-        std::lock_guard<std::mutex> guard(lock);
-        buffer.insert(at, n, ch);
-    }
-    NotifyChangeHandler();
-    return n;
-}
-
 
 void Line::Move(Line::Ref dst, int dstOfs, int srcOfs, int nChar) {
     {
@@ -129,8 +167,8 @@ void Line::Move(Line::Ref dst, int dstOfs, int srcOfs, int nChar) {
             }
         }
         // nChar now holds the length from srcOfs
-        std::string str(buffer, srcOfs, nChar);
-        dst->Append(str.c_str());
+        std::u32string str(buffer, srcOfs, nChar);
+        dst->Append(str);
         buffer.erase(srcOfs, nChar);
     }
     NotifyChangeHandler();
@@ -157,7 +195,7 @@ int Line::Unindent(size_t tabSize) {
         if (buffer.size() == 0) {
             return 0;
         }
-        static const std::string &chars = "\t\n\v\f\r ";
+        static const std::u32string &chars = U"\t\n\v\f\r ";
         maxLen = buffer.find_first_not_of(chars);
         if (maxLen == std::string::npos) {
             return 0;
@@ -181,11 +219,30 @@ Line::LineAttribIterator Line::AttributeAt(int pos) {
     return attribs.begin();
 }
 
+
 bool Line::StartsWith(const std::string &prefix) {
+
+    std::u32string u32prefix;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(u32prefix, prefix)) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(lock);
+    return strutil::startsWith(buffer, u32prefix);
+}
+
+bool Line::StartsWith(const std::string_view &prefix) {
+    std::u32string u32prefix;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(u32prefix, prefix.data())) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(lock);
+    return strutil::startsWith(buffer, u32prefix);
+}
+
+bool Line::StartsWith(const std::u32string &prefix) {
     std::lock_guard<std::mutex> guard(lock);
     return strutil::startsWith(buffer, prefix);
 }
-bool Line::StartsWith(const std::string_view &prefix) {
-    std::lock_guard<std::mutex> guard(lock);
-    return strutil::startsWith(buffer, prefix.data());
-}
+

--- a/src/Core/Line.h
+++ b/src/Core/Line.h
@@ -16,7 +16,7 @@
 #include "Core/Language/LanguageTokenClass.h"
 
 #ifndef GEDIT_MAX_LINE_LENGTH
-#define GEDIT_MAX_LINE_LENGTH 1024
+#define GEDIT_MAX_LINE_LENGTH 65536
 #endif
 
 namespace gedit {
@@ -100,6 +100,7 @@ namespace gedit {
     private:
         std::mutex lock;
         bool isLocked = false;
+        //std::u32string buffer = U"";
         std::string buffer = "";
         std::vector<LineAttrib> attribs;
         //bool active = false;

--- a/src/Core/Line.h
+++ b/src/Core/Line.h
@@ -80,8 +80,10 @@ namespace gedit {
         bool StartsWith(const std::u32string &prefix);
 
         size_t Length() const { return buffer.length(); }
+
         const std::u32string_view BufferView() const { return buffer.c_str(); }
         const std::u32string &Buffer() const { return buffer; }
+        const std::string BufferAsUTF8() const;
 
         void Lock();
         void Release();

--- a/src/Core/Line.h
+++ b/src/Core/Line.h
@@ -33,9 +33,11 @@ namespace gedit {
     public:
         Line();
         Line(const char *data);
+        Line(const std::u32string &data);
         static Line::Ref Create();
         static Line::Ref Create(const char *data);
         static Line::Ref Create(const std::string &data);
+        static Line::Ref Create(const std::u32string &data);
 
         void SetOnChangeDelegate(OnChangeDelegate newOnChangeDelegate) {
             cbChanged = newOnChangeDelegate;
@@ -46,11 +48,14 @@ namespace gedit {
         void Append(std::string_view &srcdata);
         void Append(std::string &srcdata);
         void Append(const std::string &srcdata);
+        void Append(const std::u32string &srcdata);
+        void Append(const std::u32string_view &srcdata);
         void Append(const char *srcdata);
         void Append(Line::Ref other);
 
         void Insert(int at, int ch);
         void Insert(int at, const std::string_view &srcdata);
+        void Insert(int at, const std::u32string_view &srcdata);
         int Insert(int at, int n, int ch);
 
         void Delete(int at);
@@ -72,9 +77,11 @@ namespace gedit {
 
         bool StartsWith(const std::string &prefix);
         bool StartsWith(const std::string_view &prefix);
+        bool StartsWith(const std::u32string &prefix);
 
-        size_t Length() const { return buffer.size(); }
-        const std::string_view Buffer() const { return buffer.c_str(); }
+        size_t Length() const { return buffer.length(); }
+        const std::u32string_view BufferView() const { return buffer.c_str(); }
+        const std::u32string &Buffer() const { return buffer; }
 
         void Lock();
         void Release();
@@ -100,8 +107,8 @@ namespace gedit {
     private:
         std::mutex lock;
         bool isLocked = false;
-        //std::u32string buffer = U"";
-        std::string buffer = "";
+        std::u32string buffer = U"";
+        //std::string buffer = "";
         std::vector<LineAttrib> attribs;
         //bool active = false;
         int indent = 0;

--- a/src/Core/LineRender.cpp
+++ b/src/Core/LineRender.cpp
@@ -72,12 +72,12 @@ void LineRender::DrawLineWithAttributesAt(int x, int y, int nCharToPrint, Line &
             return;
         }
         // Grab the substring for this attribute range
-        std::string strOut = std::string(l.Buffer().data(), itAttrib->idxOrigString, len);
+        auto strOut = std::u32string(l.Buffer().data(), itAttrib->idxOrigString, len);
 
         // Draw string with the correct color...
         auto [fgColor, bgColor] = Editor::Instance().ColorFromLanguageToken(itAttrib->tokenClass);
         dc.SetColor(fgColor, bgColor);
-        dc.DrawStringWithAttributesAt(xp,y, itAttrib->textAttributes, strOut.c_str());
+        dc.DrawStringWithAttributesAt(xp,y, itAttrib->textAttributes, strOut);
 
         xp += len;
         itAttrib = next;

--- a/src/Core/Plugins/PluginExecutor.cpp
+++ b/src/Core/Plugins/PluginExecutor.cpp
@@ -8,19 +8,25 @@
 #include "Core/StrUtil.h"
 
 #include "logger.h"
+#include "Core/UnicodeHelper.h"
 
 using namespace gedit;
 
-bool PluginExecutor::ParseAndExecuteWithCmdPrefix(const std::string &cmdline) {
+bool PluginExecutor::ParseAndExecuteWithCmdPrefix(const std::u32string &cmdline32) {
+    // Below is all UTF8 - as we are leaving the editor
+    // Plugin's all operate on UTF8
     auto prefix = Config::Instance()["main"].GetStr("cmdlet_prefix");
+    auto cmdline = UnicodeHelper::utf32to8(cmdline32);
+
     if (!strutil::startsWith(cmdline, prefix)) {
         return false;
     }
 
     std::string cmdLineNoPrefix = cmdline.substr(prefix.length());
+
     std::vector<std::string> commandList;
     // We should have a 'smarter' that keeps strings and so forth
-    strutil::split(commandList, cmdLineNoPrefix.data(), ' ');
+    strutil::split(commandList, cmdLineNoPrefix, ' ');
 
     // There is more to come...
     if (!RuntimeConfig::Instance().HasPluginCommand(commandList[0])) {

--- a/src/Core/Plugins/PluginExecutor.h
+++ b/src/Core/Plugins/PluginExecutor.h
@@ -9,7 +9,7 @@
 namespace gedit {
     class PluginExecutor {
     public:
-        static bool ParseAndExecuteWithCmdPrefix(const std::string &cmdline);
+        static bool ParseAndExecuteWithCmdPrefix(const std::u32string &cmdline);
     };
 }
 

--- a/src/Core/RuntimeConfig.cpp
+++ b/src/Core/RuntimeConfig.cpp
@@ -2,6 +2,7 @@
 // Created by gnilk on 14.01.23.
 //
 #include "Core/RuntimeConfig.h"
+#include "Core/UnicodeHelper.h"
 
 #ifdef GEDIT_MACOS
 #include "Core/macOS/MacOSFolderMonitor.h"
@@ -31,12 +32,21 @@ bool RuntimeConfig::HasPluginCommand(const std::string &name) {
     }
     return false;
 }
+bool RuntimeConfig::HasPluginCommand(const std::u32string &name) {
+    // We insert the same plugin command twice, once with the short name and one with the full name...
+    auto name8 = UnicodeHelper::utf32to8(name);
+    return HasPluginCommand(name8);
+}
 
 PluginCommand::Ref RuntimeConfig::GetPluginCommand(const std::string &name) {
     if (!HasPluginCommand(name)) {
         return nullptr;
     }
     return pluginCommands[name];
+}
+PluginCommand::Ref RuntimeConfig::GetPluginCommand(const std::u32string &name) {
+    auto name8 = UnicodeHelper::utf32to8(name);
+    return GetPluginCommand(name8);
 }
 
 std::vector<PluginCommand::Ref> RuntimeConfig::GetPluginCommands() {

--- a/src/Core/RuntimeConfig.h
+++ b/src/Core/RuntimeConfig.h
@@ -26,7 +26,7 @@
 namespace gedit {
     class IOutputConsole {
     public:
-        virtual void WriteLine(const std::string &str) = 0;
+        virtual void WriteLine(const std::u32string &str) = 0;
     };
     // Should have active buffer
     class RuntimeConfig {
@@ -107,7 +107,9 @@ namespace gedit {
         // Not sure this should be here - perhaps rather in the editor...
         void RegisterPluginCommand(const PluginCommand::Ref pluginCommand);
         bool HasPluginCommand(const std::string &name);
+        bool HasPluginCommand(const std::u32string &name);
         PluginCommand::Ref GetPluginCommand(const std::string &name);
+        PluginCommand::Ref GetPluginCommand(const std::u32string &name);
         std::vector<PluginCommand::Ref> GetPluginCommands();
 
     private:

--- a/src/Core/SDL2/SDLDrawContext.h
+++ b/src/Core/SDL2/SDLDrawContext.h
@@ -35,6 +35,10 @@ namespace gedit {
         void DrawStringAt(int x, int y, const char *str) const override;
         void DrawStringWithAttributesAt(int x, int y, kTextAttributes attrib, const char *str) const override;
         void DrawStringWithAttributesAndColAt(int x, int y, kTextAttributes attrib, int idxColor, const char *str) const override;
+
+        void DrawStringAt(int x, int y, const std::u32string &str) const override;
+        void DrawStringWithAttributesAt(int x, int y, kTextAttributes attrib, const std::u32string &str) const override;
+
     protected:
         void SetRenderColor() const;
         void SetRenderColor(kTextAttributes attrib) const;

--- a/src/Core/SDL2/SDLKeyboardDriver.cpp
+++ b/src/Core/SDL2/SDLKeyboardDriver.cpp
@@ -21,6 +21,7 @@
 #include "Core/RuntimeConfig.h"
 #include "Core/Editor.h"
 #include "Core/TextBuffer.h"
+#include "Core/UnicodeHelper.h"
 
 using namespace gedit;
 
@@ -65,7 +66,8 @@ KeyPress SDLKeyboardDriver::GetKeyPress() {
             kp.modifiers = TranslateModifiers(SDL_GetModState());
             // This seems to work, but I assume that we can get buffered input here
             // Need to check if there are some flags in SDL to deal with it
-            kp.key = event.text.text[0];
+            auto u32str = UnicodeHelper::utf8to32(event.text.text);
+            kp.key = u32str[0]; //event.text.text[0];
             logger->Debug("SDL_EVENT_TEXT_INPUT, event.text.text=%s", event.text.text);
             return kp;
         }  else if ((event.type == SDL_EventType::SDL_WINDOWEVENT) && (event.window.event == SDL_WINDOWEVENT_RESIZED)) {

--- a/src/Core/StrUtil.cpp
+++ b/src/Core/StrUtil.cpp
@@ -33,6 +33,23 @@ namespace strutil {
         return ltrim(rtrim(str, chars), chars);
     }
 
+    std::u32string& ltrim(std::u32string  &str, const std::u32string &chars) {
+        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [chars](char32_t ch) {
+            return (chars.find(ch) == std::u32string::npos);
+        }));
+        return str;
+    }
+    std::u32string& rtrim(std::u32string  &str, const std::u32string &chars) {
+        str.erase(std::find_if(str.rbegin(), str.rend(), [chars](char32_t ch) {
+            return (chars.find(ch) == std::u32string::npos);
+        }).base(), str.end());
+        return str;
+    }
+    std::u32string& trim(std::u32string  &str, const std::u32string &chars) {
+        return ltrim(rtrim(str, chars), chars);
+    }
+
+
     void split(std::vector<std::string> &strings, const char *strInput, int splitChar) {
         std::string input(strInput);
         size_t iPos = 0;

--- a/src/Core/StrUtil.cpp
+++ b/src/Core/StrUtil.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstring>
 #include "Core/StrUtil.h"
+#include "Core/UnicodeHelper.h"
 
 namespace strutil {
     std::string &ltrim(std::string &s, const std::string &chars /* = "\t\n\v\f\r " */) {
@@ -75,6 +76,28 @@ namespace strutil {
     void split(std::vector<std::string> &strings, const std::string &strInput, int splitChar) {
         return split(strings, strInput.c_str(), splitChar);
     }
+
+    void split(std::vector<std::u32string> &strings, const std::u32string &strInput, char32_t splitChar) {
+        size_t iPos = 0;
+        while (iPos != std::string::npos) {
+            size_t iStart = iPos;
+            iPos = strInput.find(splitChar, iPos);
+            if (iPos != std::u32string::npos) {
+                auto str = strInput.substr(iStart, iPos - iStart);
+                trim(str);
+                // 2018-11-29, Gnilk: Push back even if length is 0
+                strings.emplace_back(str);
+                iPos++;
+            } else {
+                auto str = strInput.substr(iStart, strInput.length() - iStart);
+                trim(str);
+                if (str.length() > 0) {
+                    strings.push_back(str);
+                }
+            }
+        }
+    }
+
 
 
     bool isinteger(const std::string& s) {
@@ -189,6 +212,23 @@ namespace strutil {
         return false;
     }
 
+    std::u32string itou32(int num) {
+        char tmp[32];
+        snprintf(tmp, 32, "%d", num);
+        std::u32string str;
+        gedit::UnicodeHelper::ConvertUTF8ToUTF32String(str, tmp);
+        return str;
+    }
+
+    std::u32string itou32(size_t num) {
+        char tmp[32];
+        snprintf(tmp, 32, "%zu", num);
+        std::u32string str;
+        gedit::UnicodeHelper::ConvertUTF8ToUTF32String(str, tmp);
+        return str;
+    }
+
+
     bool startsWith(const std::string &str, const std::string &prefix) {
         if (prefix.length() > str.length()) return false;
         for (size_t i = 0; i < prefix.length(); i++) {
@@ -196,6 +236,14 @@ namespace strutil {
         }
         return true;
     }
+    bool startsWith(const std::u32string &str, const std::u32string &prefix) {
+        if (prefix.length() > str.length()) return false;
+        for (size_t i = 0; i < prefix.length(); i++) {
+            if (prefix[i] != str[i]) return false;
+        }
+        return true;
+    }
+
 
 
 }

--- a/src/Core/StrUtil.h
+++ b/src/Core/StrUtil.h
@@ -10,9 +10,14 @@
 
 
 namespace strutil {
-    std::string& ltrim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
-    std::string& rtrim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
-    std::string& trim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
+    std::string& ltrim(std::string &str, const std::string &chars = "\t\n\v\f\r ");
+    std::string& rtrim(std::string &str, const std::string &chars = "\t\n\v\f\r ");
+    std::string& trim(std::string &str, const std::string &chars = "\t\n\v\f\r ");
+
+    std::u32string& ltrim(std::u32string  &str, const std::u32string &chars = U"\t\n\v\f\r ");
+    std::u32string& rtrim(std::u32string  &str, const std::u32string &chars = U"\t\n\v\f\r ");
+    std::u32string& trim(std::u32string  &str, const std::u32string &chars = U"\t\n\v\f\r ");
+
     void split(std::vector<std::string> &strings, const char *strInput, int splitChar);
     void split(std::vector<std::string> &strings, const std::string &strInput, int splitChar);
     bool isinteger(const std::string &str);

--- a/src/Core/StrUtil.h
+++ b/src/Core/StrUtil.h
@@ -20,10 +20,14 @@ namespace strutil {
 
     void split(std::vector<std::string> &strings, const char *strInput, int splitChar);
     void split(std::vector<std::string> &strings, const std::string &strInput, int splitChar);
+    void split(std::vector<std::u32string> &strings, const std::u32string &strInput, char32_t splitChar);
     bool isinteger(const std::string &str);
     bool isdouble(const std::string& s);
     uint32_t hex2dec(const char *s);
     uint32_t hex2dec(const std::string &str);
+
+    std::u32string itou32(int num);
+    std::u32string itou32(size_t num);
 
     // The following has been added from the Tokenizer code
     bool skipWhiteSpace(char **input);
@@ -32,6 +36,7 @@ namespace strutil {
     bool inStringList(std::vector<std::string> &strList, const char *input, int &outSz);
 
     bool startsWith(const std::string &str, const std::string &prefix);
+    bool startsWith(const std::u32string &str, const std::u32string &prefix);
 
 }
 

--- a/src/Core/TextBuffer.cpp
+++ b/src/Core/TextBuffer.cpp
@@ -244,10 +244,10 @@ void TextBuffer::ExecuteRegionParse(size_t idxLineStart, size_t idxLineEnd) {
     parseMetrics.region += 1;
 }
 
-void TextBuffer::CopyRegionToString(std::string &outText, const Point &start, const Point &end) {
+void TextBuffer::CopyRegionToString(std::u32string &outText, const Point &start, const Point &end) {
     for (int idxLine=start.y;idxLine<end.y;idxLine++) {
         outText += lines[idxLine]->Buffer();
-        outText += "\n";
+        outText += U"\n";
     }
 }
 
@@ -330,15 +330,16 @@ bool TextBuffer::DoSave(const std::filesystem::path &pathName, bool skipChangeCh
         logger->Error("Failed to save buffer, err: %d:%s", errno, strerror(errno));
 
         // Best dump this to the console as well..
-        std::string strError = "Unable to save file, err: ";
-        strError += strerror(errno);
+        std::u32string strError = U"Unable to save file, err: ";
+        strError += UnicodeHelper::utf8to32(strerror(errno));
         RuntimeConfig::Instance().OutputConsole()->WriteLine(strError);
         return false;
     }
 
     // Actual writing of data...
     for (auto &l: lines) {
-        fprintf(f,"%s\n", l->Buffer().data());
+        auto utf8 = UnicodeHelper::utf32to8(l->Buffer());
+        fprintf(f,"%s\n", utf8.data());
     }
     fclose(f);
 

--- a/src/Core/TextBuffer.cpp
+++ b/src/Core/TextBuffer.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 
 using namespace gedit;
@@ -383,7 +384,11 @@ void TextBuffer::OnLineChanged(const Line &line) {
     ChangeBufferState(kBuffer_Changed);
 }
 
-size_t TextBuffer::Flatten(char *outBuffer, size_t maxBytes, size_t idxFromLine, size_t nLines) {
+//
+// Flattens a number of lines and adds to 'out' - will insert CRLN at end of each line
+//
+size_t TextBuffer::Flatten(std::u32string &out, size_t idxFromLine, size_t nLines) {
+
     size_t linesCopied = 0;
     if (idxFromLine >= NumLines()) {
         return linesCopied;
@@ -392,6 +397,7 @@ size_t TextBuffer::Flatten(char *outBuffer, size_t maxBytes, size_t idxFromLine,
         nLines = NumLines();
     }
     size_t idxBuffer = 0;
+    out.clear();
 
     for(size_t i=0;i<nLines;i++) {
         auto l = LineAt(i + idxFromLine);
@@ -399,8 +405,12 @@ size_t TextBuffer::Flatten(char *outBuffer, size_t maxBytes, size_t idxFromLine,
         if (l == nullptr) {
             return linesCopied;
         }
-        snprintf(&outBuffer[idxBuffer], maxBytes - idxBuffer, "%s\n", l->Buffer().data());
-        idxBuffer += l->Length() + sizeof('\n');
+        out += l->Buffer();
+        out += U"\n";
+//        auto strutf8 = UnicodeHelper::utf32to8(l->Buffer());
+//
+//        snprintf(&outBuffer[idxBuffer], maxBytes - idxBuffer, "%s\n", l->Buffer().data());
+//        idxBuffer += l->Length() + sizeof('\n');
         linesCopied++;
     }
     return linesCopied;

--- a/src/Core/TextBuffer.h
+++ b/src/Core/TextBuffer.h
@@ -70,13 +70,14 @@ namespace gedit {
             ChangeBufferState(kBuffer_Changed);
         }
 
+        void AddLine(const std::u32string string) {
+            auto newLine = Line::Create(string);
+            AddLine(newLine);
+        }
+
         void AddLineUTF8(const char *textString) {
             auto newLine = Line::Create(textString);
-            newLine->SetOnChangeDelegate([this](const Line &line){
-                OnLineChanged(line);
-            });
-            lines.push_back(newLine);
-            ChangeBufferState(kBuffer_Changed);
+            AddLine(newLine);
         }
 
         void Insert(size_t idxPos, Line::Ref line) {
@@ -87,10 +88,6 @@ namespace gedit {
             lines.insert(it, line);
             ChangeBufferState(kBuffer_Changed);
         }
-        void Insert(size_t idxPos, const std::string &text) {
-            auto newLine = Line::Create(text);
-            Insert(idxPos, newLine);
-        }
 
         void Insert(std::vector<Line::Ref>::const_iterator it, Line::Ref line) {
             line->SetOnChangeDelegate([this](const Line &line){
@@ -98,6 +95,17 @@ namespace gedit {
             });
             lines.insert(it, line);
             ChangeBufferState(kBuffer_Changed);
+        }
+
+
+        void Insert(size_t idxPos, const std::string &text) {
+            auto newLine = Line::Create(text);
+            Insert(idxPos, newLine);
+        }
+
+        void Insert(size_t idxPos, const std::u32string &text) {
+            auto newLine = Line::Create(text);
+            Insert(idxPos, newLine);
         }
 
         const std::vector<Line::Ref> &Lines() { return lines; }
@@ -121,7 +129,7 @@ namespace gedit {
             ChangeBufferState(kBuffer_Changed);
         }
 
-        void CopyRegionToString(std::string &outText, const Point &start, const Point &end);
+        void CopyRegionToString(std::u32string &outText, const Point &start, const Point &end);
 
         void SetLanguage(LanguageBase::Ref newLanguage) {
             language = newLanguage;

--- a/src/Core/TextBuffer.h
+++ b/src/Core/TextBuffer.h
@@ -70,7 +70,7 @@ namespace gedit {
             ChangeBufferState(kBuffer_Changed);
         }
 
-        void AddLine(const char *textString) {
+        void AddLineUTF8(const char *textString) {
             auto newLine = Line::Create(textString);
             newLine->SetOnChangeDelegate([this](const Line &line){
                 OnLineChanged(line);

--- a/src/Core/TextBuffer.h
+++ b/src/Core/TextBuffer.h
@@ -139,7 +139,7 @@ namespace gedit {
         // Flatten the buffer to a regular char array with CRLN
         // nLines = 0, process as much data as possible..
         // returns the number of line..
-        size_t Flatten(char *outBuffer, size_t maxBytes, size_t idxFromLine, size_t nLines);
+        size_t Flatten(std::u32string &out, size_t idxFromLine, size_t nLines);
 
         bool HaveLanguage() { return language!= nullptr; }
         LanguageBase &GetLanguage() { return *language; }

--- a/src/Core/UndoHistory.cpp
+++ b/src/Core/UndoHistory.cpp
@@ -109,7 +109,7 @@ void UndoHistory::UndoItemRange::InitRange(const gedit::Point &ptStart, const ge
 
     for(int y=start.y; y < end.y; y++) {
         auto line = model->LineAt(y);
-        data.push_back(std::string(line->Buffer()));
+        data.push_back(line->Buffer());
     }
 }
 void UndoHistory::UndoItemRange::Restore(TextBuffer::Ref textBuffer) {

--- a/src/Core/UndoHistory.h
+++ b/src/Core/UndoHistory.h
@@ -58,7 +58,7 @@ namespace gedit {
         protected:
             void Initialize() override;
         private:
-            std::string data = {};
+            std::u32string data = {};
         };
         class UndoItemRange : public UndoItem {
             friend UndoHistory;
@@ -75,7 +75,7 @@ namespace gedit {
         private:
             Point start = {};
             Point end = {};
-            std::vector<std::string> data;
+            std::vector<std::u32string> data;
         };
 
     public:

--- a/src/Core/UnicodeHelper.cpp
+++ b/src/Core/UnicodeHelper.cpp
@@ -1,0 +1,91 @@
+//
+// Created by gnilk on 09.09.23.
+//
+
+#include "UnicodeHelper.h"
+#include "ConvertUTF.h"
+
+using namespace gedit;
+
+bool UnicodeHelper::ConvertUTF8ToUTF32String(std::u32string &out, const std::string &src) {
+    if (src.empty()) {
+        return true;
+    }
+
+
+    const UTF8 *srcStart = reinterpret_cast<const UTF8 *>(&src[0]);
+    const UTF8 *srcEnd = &srcStart[src.length()];
+
+    // Should be reserve but doesn't matter since we operate on the raw pointers
+    out.resize(src.length());
+
+    auto dstStart = reinterpret_cast<UTF32 *>(&out[0]);
+    auto dstEnd = &dstStart[out.capacity()];
+
+    auto result = ::ConvertUTF8toUTF32(&srcStart,
+                                       srcEnd,
+                                       &dstStart,
+                                       dstEnd,
+                                       strictConversion);
+
+    if (result != ConversionResult::conversionOK) {
+        return false;
+    }
+    return true;
+}
+
+bool UnicodeHelper::ConvertUTF32ToUTF8String(std::string &out, const std::u32string &src) {
+
+    if (src.empty()) {
+        return true;
+    }
+
+    const UTF32 *srcStart = reinterpret_cast<const UTF32 *>(&src[0]);
+    const UTF32 *srcEnd = &srcStart[src.length()];
+
+    // Should be reserve but doesn't matter since we operate on the raw pointers
+    out.resize(src.length() * UNI_MAX_UTF8_BYTES_PER_CODE_POINT  + 1);
+
+    UTF8 *dstStart = reinterpret_cast<UTF8 *>(&out[0]);
+    UTF8 *dstEnd = &dstStart[out.capacity()];
+
+    auto result = ::ConvertUTF32toUTF8(&srcStart,
+                                       srcEnd,
+                                       &dstStart,
+                                       dstEnd,
+                                       strictConversion);
+
+    if (result != ConversionResult::conversionOK) {
+        out.clear();
+        return false;
+    }
+    out.resize(reinterpret_cast<char *>(dstStart) - &out[0]);
+    // Zero terminate this...
+    out.push_back(0);
+    out.pop_back();
+    return true;
+}
+
+bool UnicodeHelper::ConvertUTF8ToASCII(std::string &out, const std::string &src) {
+    if (src.empty()) {
+        return true;
+    }
+
+    const UTF8 *srcStart = reinterpret_cast<const UTF8 *>(&src[0]);
+    const UTF8 *srcEnd = &srcStart[src.length()];
+
+    out.reserve(src.length() + 1);
+    while(srcStart != srcEnd) {
+        auto codePoint = *srcStart;
+        if (!(codePoint & 0x80)) {
+            out.push_back((char)(codePoint & 0x7f));
+        }
+        srcStart++;
+    }
+    // zero terminate this..
+    out.push_back(0);
+    out.pop_back();
+
+    return true;
+}
+

--- a/src/Core/UnicodeHelper.cpp
+++ b/src/Core/UnicodeHelper.cpp
@@ -8,11 +8,43 @@
 // Check this one out: https://utfcpp.sourceforge.net/
 using namespace gedit;
 
+std::u32string UnicodeHelper::utf8to32(const std::string &src) {
+    std::u32string dst;
+    ConvertUTF8ToUTF32String(dst, src);
+    return dst;
+}
+
+std::string UnicodeHelper::utf32to8(const std::u32string &src) {
+    std::string dst;
+    ConvertUTF32ToUTF8String(dst, src);
+    return dst;
+}
+
+std::string UnicodeHelper::utf32toascii(const std::u32string &src) {
+    std::string dst;
+    ConvertUTF32ToASCII(dst, src);
+    return dst;
+}
+
+std::string UnicodeHelper::utf8toascii(const char8_t *src) {
+    std::string dst;
+    auto srcstr = reinterpret_cast<const char *>(src);
+    ConvertUTF8ToASCII(dst, srcstr);
+    return dst;
+}
+
+std::string UnicodeHelper::utf8toascii(const std::string &src) {
+    std::string dst;
+    ConvertUTF8ToASCII(dst, src);
+    return dst;
+}
+
+
+
 bool UnicodeHelper::ConvertUTF8ToUTF32String(std::u32string &out, const std::string &src) {
     if (src.empty()) {
         return true;
     }
-
 
     const UTF8 *srcStart = reinterpret_cast<const UTF8 *>(&src[0]);
     const UTF8 *srcEnd = &srcStart[src.length()];
@@ -32,8 +64,41 @@ bool UnicodeHelper::ConvertUTF8ToUTF32String(std::u32string &out, const std::str
     if (result != ConversionResult::conversionOK) {
         return false;
     }
+    out.resize(reinterpret_cast<char32_t *>(dstStart) - &out[0]);
+
     return true;
 }
+bool UnicodeHelper::ConvertUTF32ToUTF8String(std::u8string &out, const std::u32string &src) {
+    if (src.empty()) {
+        return true;
+    }
+
+    const UTF32 *srcStart = reinterpret_cast<const UTF32 *>(&src[0]);
+    const UTF32 *srcEnd = &srcStart[src.length()];
+
+    // Should be reserve but doesn't matter since we operate on the raw pointers
+    out.resize(src.length() * UNI_MAX_UTF8_BYTES_PER_CODE_POINT  + 1);
+
+    UTF8 *dstStart = reinterpret_cast<UTF8 *>(&out[0]);
+    UTF8 *dstEnd = &dstStart[out.capacity()];
+
+    auto result = ::ConvertUTF32toUTF8(&srcStart,
+                                       srcEnd,
+                                       &dstStart,
+                                       dstEnd,
+                                       strictConversion);
+
+    if (result != ConversionResult::conversionOK) {
+        out.clear();
+        return false;
+    }
+    out.resize(reinterpret_cast<char8_t *>(dstStart) - &out[0]);
+    // Zero terminate this...
+    out.push_back(0);
+    out.pop_back();
+    return true;
+}
+
 
 bool UnicodeHelper::ConvertUTF32ToUTF8String(std::string &out, const std::u32string &src) {
 
@@ -67,6 +132,30 @@ bool UnicodeHelper::ConvertUTF32ToUTF8String(std::string &out, const std::u32str
     return true;
 }
 
+bool UnicodeHelper::ConvertUTF32ToASCII(std::string &out, const std::u32string &src) {
+    if (src.empty()) {
+        return true;
+    }
+    out.reserve(src.length() + 1);
+
+    size_t nConverted = 0;
+    for(auto codePoint : src) {
+        if (codePoint < 0x80) {
+            out.push_back(static_cast<char>(codePoint & 0x7f));
+            nConverted++;
+        }
+    }
+    out.resize(nConverted);
+
+    // zero terminate this..
+    out.push_back(0);
+    out.pop_back();
+
+    return true;
+
+}
+
+
 bool UnicodeHelper::ConvertUTF8ToASCII(std::string &out, const std::string &src) {
     if (src.empty()) {
         return true;
@@ -76,18 +165,7 @@ bool UnicodeHelper::ConvertUTF8ToASCII(std::string &out, const std::string &src)
     if (!UnicodeHelper::ConvertUTF8ToUTF32String(stru32, src)) {
         return false;
     }
-    out.reserve(stru32.length() + 1);
 
-    for(auto codePoint : stru32) {
-        if (codePoint < 0x80) {
-            out.push_back(static_cast<char>(codePoint & 0x7f));
-        }
-    }
-
-    // zero terminate this..
-    out.push_back(0);
-    out.pop_back();
-
-    return true;
+    return ConvertUTF32ToASCII(out, stru32);
 }
 

--- a/src/Core/UnicodeHelper.cpp
+++ b/src/Core/UnicodeHelper.cpp
@@ -5,6 +5,7 @@
 #include "UnicodeHelper.h"
 #include "ConvertUTF.h"
 
+// Check this one out: https://utfcpp.sourceforge.net/
 using namespace gedit;
 
 bool UnicodeHelper::ConvertUTF8ToUTF32String(std::u32string &out, const std::string &src) {
@@ -71,17 +72,18 @@ bool UnicodeHelper::ConvertUTF8ToASCII(std::string &out, const std::string &src)
         return true;
     }
 
-    const UTF8 *srcStart = reinterpret_cast<const UTF8 *>(&src[0]);
-    const UTF8 *srcEnd = &srcStart[src.length()];
-
-    out.reserve(src.length() + 1);
-    while(srcStart != srcEnd) {
-        auto codePoint = *srcStart;
-        if (!(codePoint & 0x80)) {
-            out.push_back((char)(codePoint & 0x7f));
-        }
-        srcStart++;
+    std::u32string stru32;
+    if (!UnicodeHelper::ConvertUTF8ToUTF32String(stru32, src)) {
+        return false;
     }
+    out.reserve(stru32.length() + 1);
+
+    for(auto codePoint : stru32) {
+        if (codePoint < 0x80) {
+            out.push_back(static_cast<char>(codePoint & 0x7f));
+        }
+    }
+
     // zero terminate this..
     out.push_back(0);
     out.pop_back();

--- a/src/Core/UnicodeHelper.h
+++ b/src/Core/UnicodeHelper.h
@@ -1,0 +1,20 @@
+//
+// Created by gnilk on 09.09.23.
+//
+
+#ifndef SDLAPP_UNICODEHELPER_H
+#define SDLAPP_UNICODEHELPER_H
+
+#include <string>
+
+namespace gedit {
+    class UnicodeHelper {
+    public:
+        static bool ConvertUTF8ToUTF32String(std::u32string &out, const std::string &src);
+        static bool ConvertUTF32ToUTF8String(std::string &out, const std::u32string &src);
+        static bool ConvertUTF8ToASCII(std::string &out, const std::string &src);
+    };
+}
+
+
+#endif //SDLAPP_UNICODEHELPER_H

--- a/src/Core/UnicodeHelper.h
+++ b/src/Core/UnicodeHelper.h
@@ -11,8 +11,17 @@ namespace gedit {
     class UnicodeHelper {
     public:
         static bool ConvertUTF8ToUTF32String(std::u32string &out, const std::string &src);
-        static bool ConvertUTF32ToUTF8String(std::string &out, const std::u32string &src);
         static bool ConvertUTF8ToASCII(std::string &out, const std::string &src);
+        static bool ConvertUTF32ToUTF8String(std::string &out, const std::u32string &src);
+        static bool ConvertUTF32ToUTF8String(std::u8string &out, const std::u32string &src);
+        static bool ConvertUTF32ToASCII(std::string &out, const std::u32string &src);
+
+
+        static std::u32string utf8to32(const std::string &src);
+        static std::string utf32to8(const std::u32string &src);
+        static std::string utf8toascii(const std::string &src);
+        static std::string utf8toascii(const char8_t *src);
+        static std::string utf32toascii(const std::u32string &src);
     };
 }
 

--- a/src/Core/Views/CommandView.cpp
+++ b/src/Core/Views/CommandView.cpp
@@ -144,7 +144,7 @@ void CommandView::DrawViewContents() {
 }
 
 // impl of IOutputConsole
-void CommandView::WriteLine(const std::string &str) {
+void CommandView::WriteLine(const std::u32string &str) {
     commandController.WriteLine(str);
     InvalidateView();
 }

--- a/src/Core/Views/CommandView.h
+++ b/src/Core/Views/CommandView.h
@@ -33,13 +33,13 @@ namespace gedit {
 
         bool OnAction(const KeyPressAction &kpAction) override;
 
-        const std::string &GetStatusBarAbbreviation() override {
-            static std::string defaultAbbr = "CMD";
+        const std::u32string &GetStatusBarAbbreviation() override {
+            static std::u32string defaultAbbr = U"CMD";
             return defaultAbbr;
         }
 
     public: // IOutputConsole
-         void WriteLine(const std::string &str) override;
+         void WriteLine(const std::u32string &str) override;
     protected:
         bool OnActionCommitLine();
     protected:

--- a/src/Core/Views/EditorView.cpp
+++ b/src/Core/Views/EditorView.cpp
@@ -13,6 +13,7 @@
 #include "EditorView.h"
 #include "Core/Editor.h"
 #include "Core/ActionHelper.h"
+#include <fmt/core.h>
 
 using namespace gedit;
 
@@ -610,9 +611,9 @@ void EditorView::SetWindowCursor(const Cursor &cursor) {
 }
 
 // returns the center and right side information for the status bar
-std::pair<std::string, std::string> EditorView::GetStatusBarInfo() {
-    std::string statusCenter = "";
-    std::string statusRight = "";
+std::pair<std::u32string, std::u32string> EditorView::GetStatusBarInfo() {
+    std::u32string statusCenter = U"";
+    std::u32string statusRight = U"";
     // If we have a model - draw details...
     auto node = Editor::Instance().GetWorkspaceNodeForActiveModel();
     if (node == nullptr) {
@@ -625,32 +626,39 @@ std::pair<std::string, std::string> EditorView::GetStatusBarInfo() {
 
     // Resolve center information
     if (model->GetTextBuffer()->GetBufferState() == TextBuffer::kBuffer_Changed) {
-        statusCenter += "* ";
+        statusCenter += U"* ";
     }
     if (model->GetTextBuffer()->IsReadOnly()) {
-        statusCenter += "R/O ";
+        statusCenter += U"R/O ";
     }
 
-    statusCenter += node->GetDisplayName();
-    statusCenter += " | ";
+    statusCenter += node->GetDisplayNameU32();
+    statusCenter += U" | ";
     if (!model->GetTextBuffer()->CanEdit()) {
-        statusCenter += "[locked] | ";
+        statusCenter += U"[locked] | ";
     }
-    statusCenter += model->GetTextBuffer()->HaveLanguage() ? model->GetTextBuffer()->GetLanguage().Identifier()                 : "none";
+    statusCenter += model->GetTextBuffer()->HaveLanguage() ? model->GetTextBuffer()->GetLanguage().Identifier() : U"none";
 
     // resolve right status
     auto activeLine = model->GetTextBuffer()->LineAt(model->idxActiveLine);
     char tmp[32];
 
-    snprintf(tmp,32,"l: %zu, c(%d:%d)",
-             idxActiveLine,
-             model->cursor.position.x, model->cursor.position.y);
+    // FIXME: Need a better snprintf for std::<t>string
+    // use: fmt?
+
+    //auto strtmp = fmt::format(U"l: {}, c({}:{})", strutil::itou32(idxActiveLine),strutil::itou32(model->cursor.position.x), strutil::itou32(model->cursor.position.x));
+    auto strtmp = U"l: " + strutil::itou32(idxActiveLine) + U", c(" + strutil::itou32(model->cursor.position.x) + U":" + strutil::itou32(model->cursor.position.x) + U")";
+
+
+//    snprintf(tmp,32,"l: %zu, c(%d:%d)",
+//             idxActiveLine,
+//             model->cursor.position.x, model->cursor.position.y);
 
 //    snprintf(tmp, 32, "Id: %d, Ln: %d, Col: %d",
 //             activeLine==nullptr?0:activeLine->Indent(),        // Line can be nullptr for 0 byte files..
 //             model->cursor.position.y,
 //             model->cursor.position.x);
-    statusRight += tmp;
+    statusRight += strtmp;
 
 
     return {statusCenter, statusRight};

--- a/src/Core/Views/EditorView.cpp
+++ b/src/Core/Views/EditorView.cpp
@@ -13,7 +13,9 @@
 #include "EditorView.h"
 #include "Core/Editor.h"
 #include "Core/ActionHelper.h"
-#include <fmt/core.h>
+
+
+#include "fmt/xchar.h"
 
 using namespace gedit;
 
@@ -641,25 +643,14 @@ std::pair<std::u32string, std::u32string> EditorView::GetStatusBarInfo() {
 
     // resolve right status
     auto activeLine = model->GetTextBuffer()->LineAt(model->idxActiveLine);
-    char tmp[32];
 
-    // FIXME: Need a better snprintf for std::<t>string
-    // use: fmt?
+    // Show Line:Row or more 'x/y' -> Configureation!
+    auto strtmp = fmt::format(U"l: {}, c({}:{})",
+                              strutil::itou32(idxActiveLine),
+                              strutil::itou32(model->cursor.position.y),
+                              strutil::itou32(model->cursor.position.x));
 
-    //auto strtmp = fmt::format(U"l: {}, c({}:{})", strutil::itou32(idxActiveLine),strutil::itou32(model->cursor.position.x), strutil::itou32(model->cursor.position.x));
-    auto strtmp = U"l: " + strutil::itou32(idxActiveLine) + U", c(" + strutil::itou32(model->cursor.position.x) + U":" + strutil::itou32(model->cursor.position.x) + U")";
-
-
-//    snprintf(tmp,32,"l: %zu, c(%d:%d)",
-//             idxActiveLine,
-//             model->cursor.position.x, model->cursor.position.y);
-
-//    snprintf(tmp, 32, "Id: %d, Ln: %d, Col: %d",
-//             activeLine==nullptr?0:activeLine->Indent(),        // Line can be nullptr for 0 byte files..
-//             model->cursor.position.y,
-//             model->cursor.position.x);
     statusRight += strtmp;
-
 
     return {statusCenter, statusRight};
 }

--- a/src/Core/Views/EditorView.h
+++ b/src/Core/Views/EditorView.h
@@ -46,11 +46,11 @@ namespace gedit {
         bool OnAction(const KeyPressAction &kpAction) override;
 
 
-        const std::string &GetStatusBarAbbreviation() override {
-            static std::string defaultAbbr = "EDT";
+        const std::u32string &GetStatusBarAbbreviation() override {
+            static std::u32string defaultAbbr = U"EDT";
             return defaultAbbr;
         }
-        std::pair<std::string, std::string> GetStatusBarInfo() override;
+        std::pair<std::u32string, std::u32string> GetStatusBarInfo() override;
 
     protected:
         void OnKeyPress(const KeyPress &keyPress) override;

--- a/src/Core/Views/HSplitViewStatus.cpp
+++ b/src/Core/Views/HSplitViewStatus.cpp
@@ -32,12 +32,12 @@ void HSplitViewStatus::DrawSplitter(int row) {
     auto logger = gnilk::Logger::GetLogger("HSplitViewStatus");
     logger->Debug("DrawSplitter, row=%d, height=%d", row, dc.GetRect().Height());
 
-    std::string viewStatusCenter = {};
-    std::string viewStatusRight = {};
+    std::u32string viewStatusCenter = {};
+    std::u32string viewStatusRight = {};
 
     //model->cursor.position.x
-    std::string dummy(dc.GetRect().Width(), ' ');
-    std::string statusLine = " " + Editor::Instance().GetAppName() + " v" + Editor::Instance().GetVersion() + " | ";
+    std::u32string dummy(dc.GetRect().Width(), U' ');
+    std::u32string statusLine = U" " + Editor::Instance().GetAppName() + U" v" + Editor::Instance().GetVersion() + U" | ";
     // Indicate whatever the editor is in edit or cmd state.
     if (Editor::Instance().GetState() == Editor::QuickCommandState) {
         auto &quickController = Editor::Instance().GetQuickCommandController();
@@ -46,7 +46,7 @@ void HSplitViewStatus::DrawSplitter(int row) {
         statusLine += quickController.GetPrompt();
         auto currentCmdLine = quickController.GetCmdLine();
         statusLine += currentCmdLine;
-        statusLine += " | ";
+        statusLine += U" | ";
     }  else {
         std::tie(viewStatusCenter, viewStatusRight) = GetStatusLineForTopview();
         statusLine += viewStatusCenter;
@@ -63,24 +63,24 @@ void HSplitViewStatus::DrawSplitter(int row) {
     }
 }
 
-std::pair<std::string,std::string> HSplitViewStatus::GetStatusLineForTopview() {
-    std::string mainStatus = "";
-    std::string rightStatus = "";
+std::pair<std::u32string,std::u32string> HSplitViewStatus::GetStatusLineForTopview() {
+    std::u32string mainStatus = U"";
+    std::u32string rightStatus = U"";
 
     // This can be cleaned up - too convoluted...
     auto rootView = RuntimeConfig::Instance().GetRootViewAs<RootView>();
     if (rootView != nullptr) {
         auto view = rootView->TopView();
         if (view != nullptr) {
-            mainStatus += view->GetStatusBarAbbreviation() + " | ";
-            std::string strCenter;
+            mainStatus += view->GetStatusBarAbbreviation() + U" | ";
+            std::u32string strCenter;
             std::tie(strCenter, rightStatus) = view->GetStatusBarInfo();
             mainStatus += strCenter;
         } else {
-            mainStatus += "E | ";
+            mainStatus += U"E | ";
         }
     } else {
-        mainStatus += "E | ";
+        mainStatus += U"E | ";
     }
     return {mainStatus, rightStatus};
 }

--- a/src/Core/Views/HSplitViewStatus.h
+++ b/src/Core/Views/HSplitViewStatus.h
@@ -25,7 +25,7 @@ namespace gedit {
         void SetWindowCursor(const Cursor &cursor) override;
 
     protected:
-        std::pair<std::string,std::string> GetStatusLineForTopview();
+        std::pair<std::u32string,std::u32string> GetStatusLineForTopview();
 
         void DrawSplitter(int row) override;
     private:

--- a/src/Core/Views/ViewBase.h
+++ b/src/Core/Views/ViewBase.h
@@ -228,12 +228,12 @@ namespace gedit {
         }
 
         // Override this in any TOPVIEW (i.e. views that can receive input) class to show an short for the active view in the statusbar
-        virtual const std::string &GetStatusBarAbbreviation() {
-            static std::string defaultAbbr = "X";
+        virtual const std::u32string &GetStatusBarAbbreviation() {
+            static std::u32string defaultAbbr = U"X";
             return defaultAbbr;
         }
-        virtual std::pair<std::string, std::string> GetStatusBarInfo() {
-            return {"",""};
+        virtual std::pair<std::u32string, std::u32string> GetStatusBarInfo() {
+            return {U"",U""};
         }
         //
         // Override these to handles, they are called in an event kind of manner on certain actions

--- a/src/Core/Views/WorkspaceView.cpp
+++ b/src/Core/Views/WorkspaceView.cpp
@@ -219,9 +219,9 @@ void WorkspaceView::OnActivate(bool isActive) {
     }
 }
 
-std::pair<std::string, std::string> WorkspaceView::GetStatusBarInfo() {
-    std::string strCenter = "apakaka";
-    std::string strRight = {};
+std::pair<std::u32string, std::u32string> WorkspaceView::GetStatusBarInfo() {
+    std::u32string strCenter = U"apakaka";
+    std::u32string strRight = {};
 
     auto node = treeView->GetCurrentSelectedItem();
     if (node == nullptr) {
@@ -242,6 +242,7 @@ std::pair<std::string, std::string> WorkspaceView::GetStatusBarInfo() {
         snprintf(tmp, 32, "---");
     }
 
-    strRight = tmp;
+    UnicodeHelper::ConvertUTF8ToUTF32String(strRight, tmp);
+
     return {strCenter, strRight};
 }

--- a/src/Core/Views/WorkspaceView.h
+++ b/src/Core/Views/WorkspaceView.h
@@ -38,11 +38,11 @@ namespace gedit {
 
         bool OnAction(const KeyPressAction &kpAction) override;
 
-        const std::string &GetStatusBarAbbreviation() override {
-            static std::string defaultAbbr = "WSP";
+        const std::u32string &GetStatusBarAbbreviation() override {
+            static std::u32string defaultAbbr = U"WSP";
             return defaultAbbr;
         }
-        std::pair<std::string, std::string> GetStatusBarInfo() override;
+        std::pair<std::u32string, std::u32string> GetStatusBarInfo() override;
     protected:
         TreeNodeRef FindModelNode(TreeNodeRef node, const std::string &pathName);
         void PopulateTree();

--- a/src/Core/Workspace.cpp
+++ b/src/Core/Workspace.cpp
@@ -70,7 +70,7 @@ Workspace::Node::Ref Workspace::NewModel(const std::string &name) {
         logger->Error("NewModel, parent is NULL or default workspace is gone");
         exit(1);
     }
-    return NewModel(parent, name);
+    return NewModelWithFileRef(parent, name);
 }
 
 // Create a new empty model under a specific parent

--- a/src/Core/Workspace.h
+++ b/src/Core/Workspace.h
@@ -20,7 +20,7 @@
 #include "Core/PathUtil.h"
 #include "Core/Config/ConfigNode.h"
 #include "EditorModel.h"
-
+#include "Core/UnicodeHelper.h"
 namespace gedit {
 
 
@@ -77,11 +77,20 @@ namespace gedit {
             const std::string &GetDisplayName() {
                 return displayName;
             }
+            // TODO: Settle for one..
+            const std::u32string GetDisplayNameU32() {
+                std::u32string u32name;
+                if (!UnicodeHelper::ConvertUTF8ToUTF32String(u32name, displayName)) {
+                    return U"INVALID UTF8";
+                }
+                return u32name;
+            }
 
             // Set the display name of an item - this is the name used in the UI
             // for a file - it's the filename, for a folder it is the last item of the full path...
             void SetDisplayName(const std::string &newDisplayName) {
                 displayName = newDisplayName;
+
             }
 
             void SetParent(Node::Ref newParent) {

--- a/src/Core/unix/Shell.h
+++ b/src/Core/unix/Shell.h
@@ -19,11 +19,11 @@
 namespace gedit {
     class Shell {
     public:
-        using OutputDelegate = std::function<void(std::string &)>;
+        using OutputDelegate = std::function<void(std::u32string &)>;
     public:
         bool Begin();
         void Close();
-        int SendCmd(std::string &cmd);
+        int SendCmd(std::u32string &cmd);
 
         void ConsumePipes();
         void CleanUp();

--- a/utests/test_clipboard.cpp
+++ b/utests/test_clipboard.cpp
@@ -29,7 +29,7 @@ DLL_EXPORT int test_clipboard_copylines(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        textBuffer->AddLine(tmp);
+        textBuffer->AddLineUTF8(tmp);
     }
     TR_ASSERT(t, clipBoard.Top() == nullptr);
     TR_ASSERT(t, clipBoard.CopyFromBuffer(textBuffer, {0,2}, {0,5}));
@@ -45,7 +45,7 @@ DLL_EXPORT int test_clipboard_copylineregion(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        textBuffer->AddLine(tmp);
+        textBuffer->AddLineUTF8(tmp);
     }
     TR_ASSERT(t, clipBoard.Top() == nullptr);
     TR_ASSERT(t, clipBoard.CopyFromBuffer(textBuffer, {2,2}, {4,2}));
@@ -62,7 +62,7 @@ DLL_EXPORT int test_clipboard_copyclippedstart(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        textBuffer->AddLine(tmp);
+        textBuffer->AddLineUTF8(tmp);
     }
     TR_ASSERT(t, clipBoard.Top() == nullptr);
     TR_ASSERT(t, clipBoard.CopyFromBuffer(textBuffer, {3,2}, {0,5}));
@@ -81,7 +81,7 @@ DLL_EXPORT int test_clipboard_paste(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        srcBuffer->AddLine(tmp);
+        srcBuffer->AddLineUTF8(tmp);
     }
     TR_ASSERT(t, clipBoard.Top() == nullptr);
     TR_ASSERT(t, clipBoard.CopyFromBuffer(srcBuffer, {0,2}, {0,5}));
@@ -111,7 +111,7 @@ DLL_EXPORT int test_clipboard_pastelineregion(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        srcBuffer->AddLine(tmp);
+        srcBuffer->AddLineUTF8(tmp);
     }
     TR_ASSERT(t, clipBoard.Top() == nullptr);
     TR_ASSERT(t, clipBoard.CopyFromBuffer(srcBuffer, {2,2}, {4,4}));
@@ -141,9 +141,9 @@ DLL_EXPORT int test_clipboard_pasteregionover(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d", i);
-        srcBuffer->AddLine(tmp);
+        srcBuffer->AddLineUTF8(tmp);
         snprintf(tmp,32,"MAMAMAMAMAMAMAMAMAM %d", i);
-        dstBuffer->AddLine(tmp);
+        dstBuffer->AddLineUTF8(tmp);
     }
 
     TR_ASSERT(t, clipBoard.Top() == nullptr);

--- a/utests/test_clipboard.cpp
+++ b/utests/test_clipboard.cpp
@@ -99,7 +99,7 @@ DLL_EXPORT int test_clipboard_paste(ITesting *t) {
     }
 
     TR_ASSERT(t, dstBuffer->NumLines() == 3);
-    TR_ASSERT(t, lines[0]->Buffer() == "line 2");
+    TR_ASSERT(t, lines[0]->Buffer() == U"line 2");
     return kTR_Pass;
 }
 
@@ -129,7 +129,7 @@ DLL_EXPORT int test_clipboard_pastelineregion(ITesting *t) {
     }
 
     TR_ASSERT(t, dstBuffer->NumLines() == 3);
-    TR_ASSERT(t, lines[0]->Buffer() == "ne 2");
+    TR_ASSERT(t, lines[0]->Buffer() == U"ne 2");
     return kTR_Pass;
 }
 
@@ -160,7 +160,7 @@ DLL_EXPORT int test_clipboard_pasteregionover(ITesting *t) {
     }
 
     TR_ASSERT(t, dstBuffer->NumLines() == 11);
-    TR_ASSERT(t, lines[4]->Buffer() == "MAne 2MAMAMAMAMAMAMAMAM 4");
+    TR_ASSERT(t, lines[4]->Buffer() == U"MAne 2MAMAMAMAMAMAMAMAM 4");
     return kTR_Pass;
 }
 DLL_EXPORT int test_clipboard_copypasteexternal(ITesting *t) {

--- a/utests/test_cpplang.cpp
+++ b/utests/test_cpplang.cpp
@@ -21,8 +21,12 @@ DLL_EXPORT int test_cpplang(ITesting *t) {
     return kTR_Pass;
 }
 DLL_EXPORT int test_cpplang_indent(ITesting *t) {
-    auto model = Editor::Instance().NewModel("test.cpp");
+    auto workspace = Editor::Instance().GetWorkspace();
+    TR_ASSERT(t, workspace != nullptr);
+    auto model = workspace->NewModel("test.cpp");
+    TR_ASSERT(t, model != nullptr);
     auto buffer = model->GetTextBuffer();
+    TR_ASSERT(t, buffer != nullptr);
 
     buffer->AddLineUTF8("if (a==b) {");
     buffer->AddLineUTF8("a");
@@ -47,8 +51,12 @@ DLL_EXPORT int test_cpplang_elseindent(ITesting *t) {
     // Switch of threading for this...
     Config::Instance()["main"].SetBool("threaded_syntaxparser", false);
 
-    auto model = Editor::Instance().NewModel("test.cpp");
+    auto workspace = Editor::Instance().GetWorkspace();
+    TR_ASSERT(t, workspace != nullptr);
+    auto model = workspace->NewModel("test.cpp");
+    TR_ASSERT(t, model != nullptr);
     auto buffer = model->GetTextBuffer();
+    TR_ASSERT(t, buffer != nullptr);
 
     buffer->AddLineUTF8("void func() {");
     buffer->AddLineUTF8("    if (a==b) {");
@@ -66,6 +74,8 @@ DLL_EXPORT int test_cpplang_elseindent(ITesting *t) {
         printf("%d: indent: %d - data: %s\n", i, line->Indent(), line->BufferAsUTF8().c_str());
         TR_ASSERT(t, line->Indent() == correntIndent[i]);
     }
+
+    TR_ASSERT(t, workspace->RemoveModel(model->GetModel()));
 
     return kTR_Pass;
 

--- a/utests/test_cpplang.cpp
+++ b/utests/test_cpplang.cpp
@@ -24,13 +24,13 @@ DLL_EXPORT int test_cpplang_indent(ITesting *t) {
     auto model = Editor::Instance().NewModel("test.cpp");
     auto buffer = model->GetTextBuffer();
 
-    buffer->AddLine("if (a==b) {");
-    buffer->AddLine("a");
-    buffer->AddLine("b");
-    buffer->AddLine("if (c==d) {");
-    buffer->AddLine("c");
-    buffer->AddLine("}");
-    buffer->AddLine("}");
+    buffer->AddLineUTF8("if (a==b) {");
+    buffer->AddLineUTF8("a");
+    buffer->AddLineUTF8("b");
+    buffer->AddLineUTF8("if (c==d) {");
+    buffer->AddLineUTF8("c");
+    buffer->AddLineUTF8("}");
+    buffer->AddLineUTF8("}");
 
     buffer->Reparse();
 
@@ -50,13 +50,13 @@ DLL_EXPORT int test_cpplang_elseindent(ITesting *t) {
     auto model = Editor::Instance().NewModel("test.cpp");
     auto buffer = model->GetTextBuffer();
 
-    buffer->AddLine("void func() {");
-    buffer->AddLine("    if (a==b) {");
-    buffer->AddLine("        ");
-    buffer->AddLine("    } else {");
-    buffer->AddLine("        ");
-    buffer->AddLine("    }");
-    buffer->AddLine("}");
+    buffer->AddLineUTF8("void func() {");
+    buffer->AddLineUTF8("    if (a==b) {");
+    buffer->AddLineUTF8("        ");
+    buffer->AddLineUTF8("    } else {");
+    buffer->AddLineUTF8("        ");
+    buffer->AddLineUTF8("    }");
+    buffer->AddLineUTF8("}");
 
     buffer->Reparse();
 

--- a/utests/test_cpplang.cpp
+++ b/utests/test_cpplang.cpp
@@ -36,7 +36,7 @@ DLL_EXPORT int test_cpplang_indent(ITesting *t) {
 
     for(int i=0;i<buffer->NumLines();i++) {
         auto line = buffer->LineAt(i);
-        printf("%d: indent: %d - data: %s\n", i, line->Indent(), line->Buffer().data());
+        printf("%d: indent: %d - data: %s\n", i, line->Indent(), line->BufferAsUTF8().c_str());
     }
 
     return kTR_Pass;
@@ -63,7 +63,7 @@ DLL_EXPORT int test_cpplang_elseindent(ITesting *t) {
     static int correntIndent[]={0,0,1,2,1,2,1,0};
     for(int i=0;i<buffer->NumLines();i++) {
         auto line = buffer->LineAt(i);
-        printf("%d: indent: %d - data: %s\n", i, line->Indent(), line->Buffer().data());
+        printf("%d: indent: %d - data: %s\n", i, line->Indent(), line->BufferAsUTF8().c_str());
         TR_ASSERT(t, line->Indent() == correntIndent[i]);
     }
 

--- a/utests/test_main.cpp
+++ b/utests/test_main.cpp
@@ -5,6 +5,7 @@
 #include "logger.h"
 #include "Core/Editor.h"
 #include "Core/RuntimeConfig.h"
+#include "Core/UnicodeHelper.h"
 
 using namespace gedit;
 
@@ -14,12 +15,13 @@ extern "C" {
 
 class UTestConsole : public IOutputConsole {
 public:
-    void WriteLine(const std::string &str) override;
+    void WriteLine(const std::u32string &str) override;
 };
 static UTestConsole utestConsole;
 
-void UTestConsole::WriteLine(const std::string &str) {
-    fprintf(stdout, "%s\n", str.c_str());
+void UTestConsole::WriteLine(const std::u32string &str) {
+    auto str8 = UnicodeHelper::utf32toascii(str);
+    fprintf(stdout, "%s\n", str8.c_str());
     fflush(stdout);
 }
 

--- a/utests/test_strutil.cpp
+++ b/utests/test_strutil.cpp
@@ -1,0 +1,66 @@
+//
+// Created by gnilk on 09.09.23.
+//
+#include <testinterface.h>
+#include <string>
+
+#include "Core/StrUtil.h"
+#include "Core/UnicodeHelper.h"
+
+
+using namespace gedit;
+
+extern "C" {
+DLL_EXPORT int test_strutil(ITesting *t);
+DLL_EXPORT int test_strutil_utf32toutf8(ITesting *t);
+DLL_EXPORT int test_strutil_utf8toascii(ITesting *t);
+DLL_EXPORT int test_strutil_ltrim32(ITesting *t);
+DLL_EXPORT int test_strutil_trim32(ITesting *t);
+}
+
+DLL_EXPORT int test_strutil(ITesting *t) {
+    return kTR_Pass;
+}
+DLL_EXPORT int test_strutil_utf32toutf8(ITesting *t) {
+    std::u32string str = U"this is utf32";
+    std::string utf8str;
+    TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
+
+    TR_ASSERT(t, utf8str == u8"this is utf32");
+    return kTR_Pass;
+}
+DLL_EXPORT int test_strutil_utf8toascii(ITesting *t) {
+    std::string src = u8"åäö-mamma";
+    std::string dst;
+    TR_ASSERT(t, UnicodeHelper::ConvertUTF8ToASCII(dst, src));
+    printf("dst: %s\n", dst.c_str());
+    TR_ASSERT(t, dst == "-mamma");
+    return kTR_Pass;
+}
+
+DLL_EXPORT int test_strutil_ltrim32(ITesting *t) {
+    std::u32string str = U"   mamma";
+    const std::u32string chars = U"\t\n\v\f\r ";
+
+    strutil::ltrim(str);
+
+    std::string utf8str;
+    TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
+    TR_ASSERT(t, utf8str == u8"mamma");
+
+    return kTR_Pass;
+}
+
+DLL_EXPORT int test_strutil_trim32(ITesting *t) {
+    std::u32string str = U"   it should only be this   ";
+    strutil::trim(str);
+
+    std::string utf8str;
+    TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
+
+    printf("trimmed: '%s'\n", utf8str.c_str());
+
+    TR_ASSERT(t, utf8str == u8"it should only be this");
+
+    return kTR_Pass;
+}

--- a/utests/test_strutil.cpp
+++ b/utests/test_strutil.cpp
@@ -23,17 +23,19 @@ DLL_EXPORT int test_strutil(ITesting *t) {
 }
 DLL_EXPORT int test_strutil_utf32toutf8(ITesting *t) {
     std::u32string str = U"this is utf32";
-    std::string utf8str;
-    TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
+    auto utf8str = UnicodeHelper::utf32to8(str);
+    TR_ASSERT(t, !utf8str.empty());
 
-    TR_ASSERT(t, utf8str == u8"this is utf32");
     return kTR_Pass;
 }
 DLL_EXPORT int test_strutil_utf8toascii(ITesting *t) {
-    std::string src = u8"åäö-mamma";
-    std::string dst;
-    TR_ASSERT(t, UnicodeHelper::ConvertUTF8ToASCII(dst, src));
+    auto src = u8"åäö-mamma";
+    auto dst = UnicodeHelper::utf8toascii(src);
+
     printf("dst: %s\n", dst.c_str());
+//    auto other = "-mamma";
+//    auto res = dst == other;
+
     TR_ASSERT(t, dst == "-mamma");
     return kTR_Pass;
 }
@@ -44,8 +46,9 @@ DLL_EXPORT int test_strutil_ltrim32(ITesting *t) {
 
     strutil::ltrim(str);
 
-    std::string utf8str;
+    std::u8string utf8str;
     TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
+
     TR_ASSERT(t, utf8str == u8"mamma");
 
     return kTR_Pass;
@@ -55,7 +58,7 @@ DLL_EXPORT int test_strutil_trim32(ITesting *t) {
     std::u32string str = U"   it should only be this   ";
     strutil::trim(str);
 
-    std::string utf8str;
+    std::u8string utf8str;
     TR_ASSERT(t, UnicodeHelper::ConvertUTF32ToUTF8String(utf8str, str));
 
     printf("trimmed: '%s'\n", utf8str.c_str());

--- a/utests/test_strutil.cpp
+++ b/utests/test_strutil.cpp
@@ -3,6 +3,7 @@
 //
 #include <testinterface.h>
 #include <string>
+#include <locale>
 
 #include "Core/StrUtil.h"
 #include "Core/UnicodeHelper.h"
@@ -16,6 +17,7 @@ DLL_EXPORT int test_strutil_utf32toutf8(ITesting *t);
 DLL_EXPORT int test_strutil_utf8toascii(ITesting *t);
 DLL_EXPORT int test_strutil_ltrim32(ITesting *t);
 DLL_EXPORT int test_strutil_trim32(ITesting *t);
+DLL_EXPORT int test_strutil_ucode(ITesting *t);
 }
 
 DLL_EXPORT int test_strutil(ITesting *t) {
@@ -64,6 +66,38 @@ DLL_EXPORT int test_strutil_trim32(ITesting *t) {
     printf("trimmed: '%s'\n", utf8str.c_str());
 
     TR_ASSERT(t, utf8str == u8"it should only be this");
+
+    return kTR_Pass;
+}
+
+// This just tests a few unicode things..
+DLL_EXPORT int test_strutil_ucode(ITesting *t) {
+
+
+    std::vector<std::u32string> lines = {
+            U"line a",
+            U"line b",
+            U"line c",
+    };
+    // flatten
+    std::u32string flattened;
+    for(auto &l : lines) {
+        flattened += l;
+        flattened += U"\n";
+    }
+    auto utf8str = UnicodeHelper::utf32to8(flattened);
+    printf("result, %zu bytes:\n'%s'\n", utf8str.length(), utf8str.c_str());
+
+    // Checking the length/size stuff UTF32 vs UTF8
+
+
+    std::u8string u8str = u8"åäö";
+    std::u32string u32str = U"åäö";
+
+    // Both returns the number of code-points (?), and u8 requires 2 code points per char
+    printf("u32 len=%zu, size=%zu\n", u32str.length(), u32str.size());
+    printf("u8  len=%zu, size=%zu\n", u8str.length(), u8str.size());
+
 
     return kTR_Pass;
 }

--- a/utests/test_textbuffer.cpp
+++ b/utests/test_textbuffer.cpp
@@ -136,7 +136,7 @@ DLL_EXPORT int test_textbuffer_flatten(ITesting *t) {
     for(int i=0;i<10;i++) {
         char tmp[32];
         snprintf(tmp,32,"line %d",i);
-        buffer->AddLine(tmp);
+        buffer->AddLineUTF8(tmp);
     }
 
 

--- a/utests/test_textbuffer.cpp
+++ b/utests/test_textbuffer.cpp
@@ -140,15 +140,16 @@ DLL_EXPORT int test_textbuffer_flatten(ITesting *t) {
     }
 
 
-    char flattenBuffer[512];
-    memset(flattenBuffer, 0, 512);
+//    char flattenBuffer[512];
+//    memset(flattenBuffer, 0, 512);
+    std::u32string flattenBuffer;
     // Below cases should stress all exit points of the function...
-    TR_ASSERT(t, 0 == buffer->Flatten(flattenBuffer, 512, 100, 10));
-    TR_ASSERT(t, 0 == buffer->Flatten(flattenBuffer, 512, buffer->NumLines(), 10));
-    TR_ASSERT(t, 5 == buffer->Flatten(flattenBuffer, 512, 5, 10));
-    TR_ASSERT(t, 5 == buffer->Flatten(flattenBuffer, 512, 5, 20));
-    TR_ASSERT(t, 10 == buffer->Flatten(flattenBuffer, 512, 0, 10));
-    TR_ASSERT(t, 10 == buffer->Flatten(flattenBuffer, 512, 0, 0));
+    TR_ASSERT(t, 0 == buffer->Flatten(flattenBuffer, 100, 10));
+    TR_ASSERT(t, 0 == buffer->Flatten(flattenBuffer, buffer->NumLines(), 10));
+    TR_ASSERT(t, 5 == buffer->Flatten(flattenBuffer, 5, 10));
+    TR_ASSERT(t, 5 == buffer->Flatten(flattenBuffer, 5, 20));
+    TR_ASSERT(t, 10 == buffer->Flatten(flattenBuffer, 0, 10));
+    TR_ASSERT(t, 10 == buffer->Flatten(flattenBuffer, 0, 0));
 
 
     return kTR_Pass;


### PR DESCRIPTION
Editor is now using U32 internally. Any data coming in externally (loading of files, clip-boards, terminal in/out) is treated as UTF-8.