### PR TITLE
keyword vs operator/separator handling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,8 @@
 //
 /*
  * TO-DO List
+ * - Language tokenizer has problem - keywords are found within other words...
+ *   Keywords, known-types MUST BE classified AFTER a token has been extracted!!! -> Need ability to create whole-token identifiers
  * - Large(?) files issue, after searching for an item and jumping to next a couple of times - scrolling up doesn't properly reposition view (need to scroll down first)
  * - Delete some lines (upper 1/3 of file) and then page-down => segfault
  *   => Seen once??
@@ -298,13 +300,17 @@ inline void exceptionHandler()
         std::cerr << "Caught unhandled exception: " << e.what();
     }
     catch(...){}
-    void *stackArray[20];
-    size_t size = backtrace(stackArray, 10);
-    std::cerr << "Segmentation fault! backtrace: ";
-    char** backtrace = backtrace_symbols(stackArray, size);
-    for (size_t i = 0; i < size; i++) {
-        std::cerr << "\t" << backtrace[i];
-    }
+
+    std::cerr << "backtrace:\n";
+    Unwind();
+
+//    void *stackArray[20];
+//    size_t size = backtrace(stackArray, 10);
+//    std::cerr << "Segmentation fault! backtrace: ";
+//    char** backtrace = backtrace_symbols(stackArray, size);
+//    for (size_t i = 0; i < size; i++) {
+//        std::cerr << "\t" << backtrace[i];
+//    }
     abort();
 }
 

--- a/src/Core/Controllers/CommandController.cpp
+++ b/src/Core/Controllers/CommandController.cpp
@@ -36,7 +36,6 @@ void CommandController::Begin() {
     });
     terminal.SetStderrDelegate([this](std::u32string &output) -> void {
 
-        strutil::trim(output);
         currentLine->Append(output);
 
         // FIXME: This is a test to use the language parser to help parse cmdline output...

--- a/src/Core/Language/LangLineTokenizer.cpp
+++ b/src/Core/Language/LangLineTokenizer.cpp
@@ -378,6 +378,7 @@ std::pair<bool, kLanguageTokenClass> LangLineTokenizer::GetNextToken(std::u32str
 
     int szOperator = 0;
     // Check if we have an identifier in the current state
+    // FIXME: ONLY classify compound identifiers (i.e. stuff allowed to 'sit' on a token - like operators)
     for(auto &kvp : currentState->identifiers) {
         if (!kvp.second->IsMatch(strInput, szOperator)) {
             continue;
@@ -416,6 +417,8 @@ std::pair<bool, kLanguageTokenClass> LangLineTokenizer::GetNextToken(std::u32str
         dst.push_back(*input);
         input++;
     }
+
+    // FIXME: Classify whole-token identifiers here (keywords, known-types)
 
     return {true, kLanguageTokenClass::kRegular};
 }

--- a/src/Core/Language/LangLineTokenizer.cpp
+++ b/src/Core/Language/LangLineTokenizer.cpp
@@ -378,8 +378,12 @@ std::pair<bool, kLanguageTokenClass> LangLineTokenizer::GetNextToken(std::u32str
 
     int szOperator = 0;
     // Check if we have an identifier in the current state
-    // FIXME: ONLY classify compound identifiers (i.e. stuff allowed to 'sit' on a token - like operators)
+
+    // Classify identifiers which can be attached, like operators: ++token  <- ++ is an attached
     for(auto &kvp : currentState->identifiers) {
+        if (kvp.second->isWholeWord) {
+            continue;
+        }
         if (!kvp.second->IsMatch(strInput, szOperator)) {
             continue;
         }
@@ -418,7 +422,16 @@ std::pair<bool, kLanguageTokenClass> LangLineTokenizer::GetNextToken(std::u32str
         input++;
     }
 
-    // FIXME: Classify whole-token identifiers here (keywords, known-types)
+    // classify whole word tokens
+    for(auto &kvp : currentState->identifiers) {
+        if (!kvp.second->isWholeWord) {
+            continue;
+        }
+        if (!kvp.second->IsMatch(strInput, szOperator)) {
+            continue;
+        }
+        return {true, kvp.second->classification};
+    }
 
     return {true, kLanguageTokenClass::kRegular};
 }

--- a/src/Core/Language/LangLineTokenizer.h
+++ b/src/Core/Language/LangLineTokenizer.h
@@ -42,17 +42,26 @@ namespace gedit {
         // Consider: Ability to set user supplied matching function...
         struct IdentifierList {
             using Ref = std::shared_ptr<IdentifierList>;
-            static IdentifierList::Ref Factory(kLanguageTokenClass tokenClass, const std::u32string &strTokens) {
+            static IdentifierList::Ref Create(kLanguageTokenClass tokenClass, const std::u32string &strTokens) {
                 auto instance = std::make_shared<IdentifierList>();
 
+                instance->isWholeWord = false;
                 instance->classification = tokenClass;
                 strutil::splitToStringList(instance->tokens, strTokens);
 
                 return instance;
             }
 
-            kLanguageTokenClass classification;
-            std::vector<std::u32string> tokens;
+            static IdentifierList::Ref Create(kLanguageTokenClass tokenClass, bool wholeWord, const std::u32string &strTokens) {
+                auto instance = std::make_shared<IdentifierList>();
+
+                instance->isWholeWord = wholeWord;
+                instance->classification = tokenClass;
+                strutil::splitToStringList(instance->tokens, strTokens);
+
+                return instance;
+            }
+
 
             __inline bool IsMatch(const std::u32string &input, int &outSzToken) {
                 for (auto s: tokens) {
@@ -63,6 +72,11 @@ namespace gedit {
                 }
                 return false;
             }
+
+            bool isWholeWord = false;
+            kLanguageTokenClass classification;
+            std::vector<std::u32string> tokens;
+
         };
 
         // TO-DO: Quite a large internal class - consider putting it somewhere else??
@@ -150,7 +164,7 @@ namespace gedit {
             // Like for CPP you want '*/' as postfix-operator in the block_comment state...
             //
             void SetPostFixIdentifiers(const std::u32string &strTokens) {
-                postfixIdentifiers = IdentifierList::Factory(kLanguageTokenClass::kRegular, strTokens);
+                postfixIdentifiers = IdentifierList::Create(kLanguageTokenClass::kRegular, strTokens);
             }
 
             //
@@ -162,7 +176,12 @@ namespace gedit {
             // Each identifier list belongs to a classification
             //
             void SetIdentifiers(kLanguageTokenClass classification, const std::u32string &strTokens) {
-                auto identifierList = IdentifierList::Factory(classification, strTokens);
+                auto identifierList = IdentifierList::Create(classification, strTokens);
+                identifiers[classification] = identifierList;
+            }
+
+            void SetIdentifiers(kLanguageTokenClass classification, bool wholeWord, const std::u32string &strTokens) {
+                auto identifierList = IdentifierList::Create(classification, wholeWord, strTokens);
                 identifiers[classification] = identifierList;
             }
 

--- a/src/Core/Language/LangToken.cpp
+++ b/src/Core/Language/LangToken.cpp
@@ -21,6 +21,7 @@ static const std::unordered_map<kLanguageTokenClass, std::string> tokenNames = {
         {kLanguageTokenClass::kRegular,"regular"},
         {kLanguageTokenClass::kOperator,"operator"},
         {kLanguageTokenClass::kKeyword,"keyword"},
+        {kLanguageTokenClass::kSeparator,"separator"},
         {kLanguageTokenClass::kKnownType,"known_type"},
         // FIXME: Implement this => Require custom matching for identifiers => see note in "identifierlist"
         {kLanguageTokenClass::kNumber,"number"},
@@ -75,7 +76,7 @@ namespace gedit {
     const std::string &LanguageTokenClassToString(kLanguageTokenClass tokenClass) {
         auto it = tokenNames.find(tokenClass);
         if (it == tokenNames.end()) {
-            printf("%s - UNSUPPORTED TOKEN CLASS (%d), UPDATE THE ARRAY!!!!\n", __FILE_NAME__, tokenClass);
+            printf("%s - UNSUPPORTED TOKEN CLASS (%d), UPDATE THE ARRAY!!!!\n", __FILE__, tokenClass);
             exit(1);
         }
         return it->second;

--- a/src/Core/Language/LanguageSupport/CPPLanguage.cpp
+++ b/src/Core/Language/LanguageSupport/CPPLanguage.cpp
@@ -14,7 +14,7 @@ using namespace gedit;
 
 // state: main (and probably a few others)
 static const std::u32string cppTypes = U"void int char";
-static const std::u32string cppKeywords = U"auto typedef class struct static enum for while if return const";
+static const std::u32string cppKeywords = U"auto typedef class struct static enum for while if else return const";
 // Note: Multi char operators must be declared first...
 static const std::u32string cppOperators = U"== ++ -- << >> <= >= != += -= *= /= &= ^= |= -> && || :: ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' \"";
 // The full operator set is used to identify post-fix operators but not used for classification..

--- a/src/Core/Language/LanguageSupport/CPPLanguage.cpp
+++ b/src/Core/Language/LanguageSupport/CPPLanguage.cpp
@@ -13,13 +13,20 @@
 using namespace gedit;
 
 // state: main (and probably a few others)
-static const std::u32string cppTypes = U"void int char";
-static const std::u32string cppKeywords = U"auto typedef class struct static enum for while if else return const";
+static const std::u32string cppTypes = U"char char8_t char16_t char32_t double float int long short signed unsigned void wchar_t";
+
+// see: https://en.cppreference.com/w/cpp/keyword
+// Perhaps break this up a bit - like C++20, and so forth..
+static const std::u32string cppKeywords = U"alignas alignof and and_eq asm auto bitand bitor bool break case catch class compl concept const conteval constexpr constinit const_cast continue co_await co_return co_yield decltype default delete do dynamic_cast else enum explicit export extern false final for friend goto if import inline module mutable namespace new noexcept not not_eq nullptr operator or or_eq override private protected public reflexpr register reinterpret_cast requires return sizeof static static_assert static_cast struct switch synchronized template this thread_local throw true try typedef typeid typename union using virtual volatile while xor xor_eq";
+
+// see: https://en.cppreference.com/w/cpp/language/punctuators
 // Note: Multi char operators must be declared first...
-static const std::u32string cppOperators = U"== ++ -- << >> <= >= != += -= *= /= &= ^= |= -> && || :: ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' \"";
+static const std::u32string cppOperators = U"... <<= >>= == ++ -- << >> <= >= != += -= *= /= %= &= ^= |= -> && || .* : | % ~ ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' \"";
+//static const std::u32string cppSeparators = U"... ## # ( ) { } ; [ ] : ";
 // The full operator set is used to identify post-fix operators but not used for classification..
 // missing: % and %=
-static const std::u32string cppOperatorsFull = U"== ++ -- << >> <= >= != += -= *= /= &= ^= |= :: /* */ // -> && || ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' { } \" \'";
+static const std::u32string cppOperatorsFull = U"... <<= >>= == ++ -- << >> <= >= != += -= *= /= %= &= ^= |= -> && || .* : | % ~ ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' \"";
+//static const std::u32string cppOperatorsFull = U"== ++ -- << >> <= >= != += -= *= /= &= ^= |= :: /* */ // -> && || ^ & ? : ! . = + - < > ( , * / ) [ ] < > ; ' { } \" '";
 static const std::u32string cppLineComment = U"//";
 static const std::u32string cppCodeBlockStart = U"{";
 static const std::u32string cppCodeBlockEnd = U"}";
@@ -41,8 +48,8 @@ static const std::u32string inCharPostFixOp = U"'";
 bool CPPLanguage::Initialize() {
     auto state = tokenizer.GetOrAddState("main");
     state->SetIdentifiers(kLanguageTokenClass::kOperator, cppOperators);
-    state->SetIdentifiers(kLanguageTokenClass::kKeyword, cppKeywords);
-    state->SetIdentifiers(kLanguageTokenClass::kKnownType, cppTypes);
+    state->SetIdentifiers(kLanguageTokenClass::kKeyword, true, cppKeywords);
+    state->SetIdentifiers(kLanguageTokenClass::kKnownType, true, cppTypes);
     state->SetIdentifiers(kLanguageTokenClass::kLineComment, cppLineComment);
     state->SetIdentifiers(kLanguageTokenClass::kBlockComment, cppBlockCommentStart);
     state->SetIdentifiers(kLanguageTokenClass::kCodeBlockStart, cppCodeBlockStart);

--- a/src/Core/Language/LanguageSupport/JSONLanguage.cpp
+++ b/src/Core/Language/LanguageSupport/JSONLanguage.cpp
@@ -30,7 +30,7 @@ bool JSONLanguage::Initialize() {
 
     auto state = tokenizer.GetOrAddState("main");
     state->SetIdentifiers(kLanguageTokenClass::kOperator, jsonOperatorsFull);
-    state->SetIdentifiers(kLanguageTokenClass::kKeyword, jsonKeywords);
+    state->SetIdentifiers(kLanguageTokenClass::kKeyword, true,jsonKeywords);
     state->SetIdentifiers(kLanguageTokenClass::kCodeBlockStart, jsonObjectStart);
     state->SetIdentifiers(kLanguageTokenClass::kCodeBlockEnd, jsonObjectEnd);
     state->SetIdentifiers(kLanguageTokenClass::kArrayStart, jsonArrayStart);

--- a/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
+++ b/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
@@ -7,7 +7,7 @@
 
 using namespace gedit;
 
-static const std::u32string makeKeywords = U"error";
+static const std::u32string makeKeywords = U"error warning";
 static const std::u32string makeOperators = U"*** : ^";
 
 
@@ -33,7 +33,7 @@ void MakeBuildLang::OnPostProcessParsedLine(Line::Ref line) {
 
     for(size_t i=0;i<parts.size();i++) {
         auto &part = parts[i];
-        if ((part.attrib.tokenClass == kLanguageTokenClass::kKeyword) && (part.string == U"error")) {
+        if ((part.attrib.tokenClass == kLanguageTokenClass::kKeyword) && ((part.string == U"error") || (part.string == U"warning"))) {
             // have error - what do we do now..   =)
             printf("Build error detected (parts: %zu)\n", parts.size());
             printf("  file: %s\n", UnicodeHelper::utf32to8(parts[0].string).c_str());

--- a/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
+++ b/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
@@ -7,14 +7,14 @@
 
 using namespace gedit;
 
-static const std::u32string makeKeywords = U"error wef";
+static const std::u32string makeKeywords = U"error";
 static const std::u32string makeOperators = U"*** : ^";
 
 
 bool MakeBuildLang::Initialize() {
     auto state = tokenizer.GetOrAddState("main");
     state->SetIdentifiers(kLanguageTokenClass::kOperator, makeOperators);
-    state->SetIdentifiers(kLanguageTokenClass::kKeyword, makeKeywords);
+    state->SetIdentifiers(kLanguageTokenClass::kKeyword, true, makeKeywords);
     state->SetPostFixIdentifiers(makeOperators);
 
     tokenizer.SetStartState("main");
@@ -34,9 +34,6 @@ void MakeBuildLang::OnPostProcessParsedLine(Line::Ref line) {
     for(size_t i=0;i<parts.size();i++) {
         auto &part = parts[i];
         if ((part.attrib.tokenClass == kLanguageTokenClass::kKeyword) && (part.string == U"error")) {
-            if (parts.size() == 4) {
-                int breakme = 1;
-            }
             // have error - what do we do now..   =)
             printf("Build error detected (parts: %zu)\n", parts.size());
             printf("  file: %s\n", UnicodeHelper::utf32to8(parts[0].string).c_str());

--- a/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
+++ b/src/Core/Language/LanguageSupport/MakeBuildLang.cpp
@@ -7,7 +7,7 @@
 
 using namespace gedit;
 
-static const std::u32string makeKeywords = U"error";
+static const std::u32string makeKeywords = U"error wef";
 static const std::u32string makeOperators = U"*** : ^";
 
 
@@ -34,8 +34,11 @@ void MakeBuildLang::OnPostProcessParsedLine(Line::Ref line) {
     for(size_t i=0;i<parts.size();i++) {
         auto &part = parts[i];
         if ((part.attrib.tokenClass == kLanguageTokenClass::kKeyword) && (part.string == U"error")) {
+            if (parts.size() == 4) {
+                int breakme = 1;
+            }
             // have error - what do we do now..   =)
-            printf("Build error detected\n");
+            printf("Build error detected (parts: %zu)\n", parts.size());
             printf("  file: %s\n", UnicodeHelper::utf32to8(parts[0].string).c_str());
             printf("  line: %s\n", UnicodeHelper::utf32to8(parts[2].string).c_str());
             printf("  row : %s\n", UnicodeHelper::utf32to8(parts[4].string).c_str());

--- a/src/Core/Language/LanguageTokenClass.h
+++ b/src/Core/Language/LanguageTokenClass.h
@@ -12,19 +12,20 @@ namespace gedit {
         kRegular = 1,
         kOperator = 2,
         kKeyword = 3,
-        kKnownType = 4,
+        kSeparator = 4,
+        kKnownType = 5,
         // FIXME: Implement this => Require custom matching for identifiers => see note in "identifierlist"
-        kNumber = 5,
-        kString = 6,
-        kLineComment = 7,
-        kBlockComment = 8,
-        kCommentedText = 9,
-        kCodeBlockStart = 10,
-        kCodeBlockEnd = 11,
-        kArrayStart = 12,
-        kArrayEnd = 13,
-        kChar = 14,
-        kLastTokenClass = 15,         // this is used as numeric detection of the last token class
+        kNumber = 6,
+        kString = 7,
+        kLineComment = 8,
+        kBlockComment = 9,
+        kCommentedText = 10,
+        kCodeBlockStart = 11,
+        kCodeBlockEnd = 12,
+        kArrayStart = 13,
+        kArrayEnd = 14,
+        kChar = 15,
+        kLastTokenClass = 16,         // this is used as numeric detection of the last token class
         kFunky = 196,       // USED for debugging..
     };
 }

--- a/utests/test_cpplang.cpp
+++ b/utests/test_cpplang.cpp
@@ -208,8 +208,8 @@ DLL_EXPORT int test_cpplang_keywords(ITesting *t) {
 
 //    buffer->AddLineUTF8("char *str=\"apa\"; // comment2");
     buffer->AddLineUTF8("ifelsevoidstatic");
+    buffer->AddLineUTF8("if else void static");
     buffer->Reparse();
-    auto line = buffer->LineAt(1);
 
     struct Part {
         Line::LineAttrib attrib;
@@ -224,6 +224,13 @@ DLL_EXPORT int test_cpplang_keywords(ITesting *t) {
         part.string = strOut;
         parts.push_back(part);
     };
+
+    auto line = buffer->LineAt(1);
+    line->IterateWithAttributes(callback);
+    TR_ASSERT(t, line->Attributes().size() == 1);
+
+    parts.clear();
+    line = buffer->LineAt(2);
     line->IterateWithAttributes(callback);
 
     printf("ATTRIB: %zu\n", line->Attributes().size());


### PR DESCRIPTION
The keyword handling was wrong - allowing keywords to be detected when in a chunk chars..
like 'ifelseswitch' would be detected as 'if', 'else', 'switch' - which is wrong.